### PR TITLE
IPv6 (dual stack)

### DIFF
--- a/config/idhash.go
+++ b/config/idhash.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"net"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func mkBuiltinAddr4(p peer.ID) net.IP {
+	builtinAddr := []byte{100, 64, 1, 2}
+	for i, b := range []byte(p) {
+		builtinAddr[(i%2)+2] ^= b
+	}
+	return net.IP(builtinAddr).To4()
+}
+
+func mkBuiltinAddr6(p peer.ID) net.IP {
+	builtinAddr := []byte("\xfd\x00hyprspace\x00\xde\xad\xbe\xef")
+	for i, b := range []byte(p) {
+		builtinAddr[(i%4)+12] ^= b
+	}
+	return net.IP(builtinAddr).To16()
+}

--- a/dns/server.go
+++ b/dns/server.go
@@ -87,11 +87,11 @@ func MagicDnsServer(ctx context.Context, config config.Config, node host.Host) {
 			case dns.TypeA:
 				if qpeer, err := peer.Decode(strings.TrimSuffix(q.Name, "."+domainSuffix(config))); err == nil {
 					if qpeer == node.ID() {
-						m.Answer = append(m.Answer, mkIDRecord(config, node.ID(), config.BuiltinAddr))
+						m.Answer = append(m.Answer, mkIDRecord(config, node.ID(), config.BuiltinAddr4))
 					} else {
 						for _, p := range config.Peers {
 							if p.ID == qpeer {
-								m.Answer = append(m.Answer, mkIDRecord(config, p.ID, p.BuiltinAddr))
+								m.Answer = append(m.Answer, mkIDRecord(config, p.ID, p.BuiltinAddr4))
 								break
 							}
 						}
@@ -106,10 +106,10 @@ func MagicDnsServer(ctx context.Context, config config.Config, node host.Host) {
 
 					if qName == strings.ToLower(hostname) {
 						m.Answer = append(m.Answer, mkAliasRecord(config, qName, node.ID()))
-						m.Answer = append(m.Answer, mkIDRecord(config, node.ID(), config.BuiltinAddr))
+						m.Answer = append(m.Answer, mkIDRecord(config, node.ID(), config.BuiltinAddr4))
 					} else if p, found := config.PeerLookup.ByName[qName]; found {
 						m.Answer = append(m.Answer, mkAliasRecord(config, qName, p.ID))
-						m.Answer = append(m.Answer, mkIDRecord(config, p.ID, p.BuiltinAddr))
+						m.Answer = append(m.Answer, mkIDRecord(config, p.ID, p.BuiltinAddr4))
 					}
 				}
 			}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -60,10 +60,15 @@ func (hsr *HyprspaceRPC) Route(args *RouteArgs, reply *RouteReply) error {
 	switch args.Action {
 	case Show:
 		var routeInfos []RouteInfo
-		allRoutes, err := hsr.config.PeerLookup.ByRoute.CoveredNetworks(*cidranger.AllIPv4)
+		allRoutes4, err := hsr.config.PeerLookup.ByRoute.CoveredNetworks(*cidranger.AllIPv4)
 		if err != nil {
 			return err
 		}
+		allRoutes6, err := hsr.config.PeerLookup.ByRoute.CoveredNetworks(*cidranger.AllIPv6)
+		if err != nil {
+			return err
+		}
+		allRoutes := append(allRoutes4, allRoutes6...)
 		for _, r := range allRoutes {
 			rte := *r.(*config.RouteTableEntry)
 			connected := hsr.host.Network().Connectedness(rte.Target.ID) == network.Connected


### PR DESCRIPTION
- Assigns built-in /128 addresses for itself and its peers
- Routes IPv4 and IPv6 based on protocol version
- Displays IPv4 and IPv6 routes in `hyprspace route show`