### PR TITLE
Service Network

### DIFF
--- a/cli/up.go
+++ b/cli/up.go
@@ -169,6 +169,15 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 
 	serviceNet := svc.NewServiceNetwork(host, cfg, tunDev)
 
+	for name, addr := range cfg.Services {
+		proxy, err := svc.ProxyTo(addr)
+		checkErr(err)
+		serviceNet.Register(
+			name,
+			proxy,
+		)
+	}
+
 	// Write lock to filesystem to indicate an existing running daemon.
 	err = os.WriteFile(lockPath, []byte(fmt.Sprint(os.Getpid())), os.ModePerm)
 	checkErr(err)

--- a/cli/up.go
+++ b/cli/up.go
@@ -20,6 +20,7 @@ import (
 	hsdns "github.com/hyprspace/hyprspace/dns"
 	"github.com/hyprspace/hyprspace/p2p"
 	hsrpc "github.com/hyprspace/hyprspace/rpc"
+	"github.com/hyprspace/hyprspace/svc"
 	"github.com/hyprspace/hyprspace/tun"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/event"
@@ -166,6 +167,8 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 		fmt.Printf("[+] Listening for metrics scrape requests on http://%s/metrics\n", metricsTuple)
 	}
 
+	serviceNet := svc.NewServiceNetwork(host.ID(), tunDev)
+
 	// Write lock to filesystem to indicate an existing running daemon.
 	err = os.WriteFile(lockPath, []byte(fmt.Sprint(os.Getpid())), os.ModePerm)
 	checkErr(err)
@@ -176,6 +179,8 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 		checkErr(errors.New("unable to bring up tun device"))
 	}
 	checkErr(tunDev.Apply(routeOpts...))
+
+	checkErr(tunDev.Apply(tun.Route(serviceNet.NetworkRange)))
 
 	fmt.Println("[+] Network setup complete")
 
@@ -210,6 +215,18 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 		} else if proto == 0x60 {
 			dstIP = net.IP(packet[24:40])
 			if cfg.BuiltinAddr6.Equal(dstIP) {
+				continue
+			} else if serviceNet.NetworkRange.Contains(dstIP) {
+				// Are you TCP because your protocol is 6, or is your protocol 6 because you are TCP?
+				if packet[6] == 0x06 {
+					port := uint16(packet[42])*256 + uint16(packet[43])
+					if serviceNet.EnsureListener([16]byte(packet[24:40]), port) {
+						count, err := (*serviceNet.Tun).Write([][]byte{packet}, 0)
+						if count == 0 {
+							fmt.Printf("[!] To service network: %s\n", err)
+						}
+					}
+				}
 				continue
 			}
 		} else {

--- a/cli/up.go
+++ b/cli/up.go
@@ -167,7 +167,7 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 		fmt.Printf("[+] Listening for metrics scrape requests on http://%s/metrics\n", metricsTuple)
 	}
 
-	serviceNet := svc.NewServiceNetwork(host.ID(), tunDev)
+	serviceNet := svc.NewServiceNetwork(host, cfg, tunDev)
 
 	// Write lock to filesystem to indicate an existing running daemon.
 	err = os.WriteFile(lockPath, []byte(fmt.Sprint(os.Getpid())), os.ModePerm)

--- a/config/config.go
+++ b/config/config.go
@@ -17,16 +17,18 @@ import (
 
 // Config is the main Configuration Struct for Hyprspace.
 type Config struct {
-	Path                   string                `json:"-"`
-	Interface              string                `json:"-"`
-	EncodedListenAddresses []string              `json:"listenAddresses"`
-	ListenAddresses        []multiaddr.Multiaddr `json:"-"`
-	Peers                  []Peer                `json:"peers"`
-	PeerLookup             PeerLookup            `json:"-"`
-	EncodedPrivateKey      string                `json:"privateKey"`
-	PrivateKey             crypto.PrivKey        `json:"-"`
-	BuiltinAddr4           net.IP                `json:"-"`
-	BuiltinAddr6           net.IP                `json:"-"`
+	Path                   string                         `json:"-"`
+	Interface              string                         `json:"-"`
+	EncodedListenAddresses []string                       `json:"listenAddresses"`
+	ListenAddresses        []multiaddr.Multiaddr          `json:"-"`
+	Peers                  []Peer                         `json:"peers"`
+	PeerLookup             PeerLookup                     `json:"-"`
+	EncodedPrivateKey      string                         `json:"privateKey"`
+	PrivateKey             crypto.PrivKey                 `json:"-"`
+	BuiltinAddr4           net.IP                         `json:"-"`
+	BuiltinAddr6           net.IP                         `json:"-"`
+	EncodedServices        map[string]string              `json:"services,omitempty"`
+	Services               map[string]multiaddr.Multiaddr `json:"-"`
 }
 
 // Peer defines a peer in the configuration. We might add more to this later.
@@ -150,6 +152,15 @@ func Read(path string) (*Config, error) {
 		}
 		result.PeerLookup.ByNetID[[4]byte(p.BuiltinAddr6[12:16])] = p
 		result.Peers[i] = p
+	}
+
+	result.Services = make(map[string]multiaddr.Multiaddr)
+	for name, addrString := range result.EncodedServices {
+		addr, err := multiaddr.NewMultiaddr(addrString)
+		if err != nil {
+			return nil, err
+		}
+		result.Services[name] = addr
 	}
 
 	// Overwrite path of config to input.

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type Route struct {
 type PeerLookup struct {
 	ByRoute cidranger.Ranger
 	ByName  map[string]Peer
+	ByNetID map[[4]byte]Peer
 }
 
 type RouteTableEntry struct {
@@ -109,6 +110,7 @@ func Read(path string) (*Config, error) {
 
 	result.PeerLookup.ByRoute = cidranger.NewPCTrieRanger()
 	result.PeerLookup.ByName = make(map[string]Peer)
+	result.PeerLookup.ByNetID = make(map[[4]byte]Peer)
 
 	for i, p := range result.Peers {
 		p.BuiltinAddr4 = mkBuiltinAddr4(p.ID)
@@ -146,6 +148,7 @@ func Read(path string) (*Config, error) {
 		if p.Name != "" {
 			result.PeerLookup.ByName[strings.ToLower(p.Name)] = p
 		}
+		result.PeerLookup.ByNetID[[4]byte(p.BuiltinAddr6[12:14])] = p
 		result.Peers[i] = p
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -148,7 +148,7 @@ func Read(path string) (*Config, error) {
 		if p.Name != "" {
 			result.PeerLookup.ByName[strings.ToLower(p.Name)] = p
 		}
-		result.PeerLookup.ByNetID[[4]byte(p.BuiltinAddr6[12:14])] = p
+		result.PeerLookup.ByNetID[[4]byte(p.BuiltinAddr6[12:16])] = p
 		result.Peers[i] = p
 	}
 

--- a/config/idhash.go
+++ b/config/idhash.go
@@ -15,21 +15,30 @@ func mkBuiltinAddr4(p peer.ID) net.IP {
 }
 
 func mkBuiltinAddr6(p peer.ID) net.IP {
-	builtinAddr := []byte("\xfd\x00hyprspace\x00\xde\xad\xbe\xef")
+	builtinAddr := []byte("\xfd\x00hyprspace\x00\x00\x00\x00\x00")
 	for i, b := range []byte(p) {
 		builtinAddr[(i%4)+12] ^= b
 	}
+	netId := MkNetID(p)
+	builtinAddr[12], builtinAddr[13], builtinAddr[14], builtinAddr[15] = netId[0], netId[1], netId[2], netId[3]
 	return net.IP(builtinAddr).To16()
 }
 
 func MkServiceAddr6(p peer.ID, serviceName string) net.IP {
-	serviceAddr := []byte("\xfd\x00hyprspsv\xde\xad\xbe\xef\x00\x00")
-	for i, b := range []byte(p) {
-		serviceAddr[(i%4)+10] ^= b
-	}
+	serviceAddr := []byte("\xfd\x00hyprspsv\x00\x00\x00\x00\x00\x00")
+	netId := MkNetID(p)
+	serviceAddr[10], serviceAddr[11], serviceAddr[12], serviceAddr[13] = netId[0], netId[1], netId[2], netId[3]
 	svcId := MkServiceID(serviceName)
 	serviceAddr[14], serviceAddr[15] = svcId[0], svcId[1]
 	return net.IP(serviceAddr).To16()
+}
+
+func MkNetID(p peer.ID) [4]byte {
+	r := [4]byte{0xde, 0xad, 0xbe, 0xef}
+	for i, b := range []byte(p) {
+		r[i%4] ^= b
+	}
+	return r
 }
 
 func MkServiceID(serviceName string) [2]byte {

--- a/config/idhash.go
+++ b/config/idhash.go
@@ -21,3 +21,21 @@ func mkBuiltinAddr6(p peer.ID) net.IP {
 	}
 	return net.IP(builtinAddr).To16()
 }
+
+func MkServiceAddr6(p peer.ID, serviceName string) net.IP {
+	serviceAddr := []byte("\xfd\x00hyprspsv\xde\xad\xbe\xef\x00\x00")
+	for i, b := range []byte(p) {
+		serviceAddr[(i%4)+10] ^= b
+	}
+	svcId := MkServiceID(serviceName)
+	serviceAddr[14], serviceAddr[15] = svcId[0], svcId[1]
+	return net.IP(serviceAddr).To16()
+}
+
+func MkServiceID(serviceName string) [2]byte {
+	var id = [2]byte{0xff, 0xfe}
+	for i, b := range []byte(serviceName) {
+		id[i%2] ^= b * byte(i)
+	}
+	return id
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyprspace/hyprspace
 
-go 1.21
+go 1.22.0
 
 toolchain go1.22.2
 
@@ -13,14 +13,19 @@ require (
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
-	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netlink v1.1.1-0.20211118161826-650dca95af54
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 )
 
 require (
 	github.com/Jorropo/jsync v1.0.1 // indirect
+	github.com/google/btree v1.1.2 // indirect
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.2 // indirect
 	github.com/samber/lo v1.36.0 // indirect
 	go.uber.org/mock v0.4.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
+	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
+	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
+github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -384,9 +386,9 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
-github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
-github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netlink v1.1.1-0.20211118161826-650dca95af54 h1:8mhqcHPqTMhSPoslhGYihEgSfc77+7La1P6kiB6+9So=
+github.com/vishvananda/netlink v1.1.1-0.20211118161826-650dca95af54/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSDJfjId/PEGEShv6ugrt4kYsC5UIDaQ=
@@ -505,10 +507,11 @@ golang.org/x/sys v0.0.0-20181029174526-d69651ed3497/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -560,6 +563,10 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
+golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
+golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 gonum.org/v1/gonum v0.14.0 h1:2NiG67LD1tEH0D7kM+ps2V+fXmsAnpUeec7n8tcr4S0=
 gonum.org/v1/gonum v0.14.0/go.mod h1:AoWeoz0becf9QMWtE8iWXNXc27fK4fNeHNf/oMejGfU=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -611,6 +618,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/netstack/tun.go
+++ b/netstack/tun.go
@@ -1,0 +1,1058 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+// taken from https://git.zx2c4.com/wireguard-go/tree/tun/netstack/tun.go
+// rev 2b73054b299aec80cbb064954001810d30ee2e3c
+
+package netstack
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.zx2c4.com/wireguard/tun"
+
+	"golang.org/x/net/dns/dnsmessage"
+	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/icmp"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+type netTun struct {
+	ep             *channel.Endpoint
+	stack          *stack.Stack
+	events         chan tun.Event
+	incomingPacket chan *buffer.View
+	mtu            int
+	dnsServers     []netip.Addr
+	hasV4, hasV6   bool
+}
+
+type Net netTun
+
+func CreateNetTUN(localAddresses, dnsServers []netip.Addr, mtu int) (tun.Device, *Net, error) {
+	opts := stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol6, icmp.NewProtocol4},
+		HandleLocal:        true,
+	}
+	dev := &netTun{
+		ep:             channel.New(1024, uint32(mtu), ""),
+		stack:          stack.New(opts),
+		events:         make(chan tun.Event, 10),
+		incomingPacket: make(chan *buffer.View),
+		dnsServers:     dnsServers,
+		mtu:            mtu,
+	}
+	sackEnabledOpt := tcpip.TCPSACKEnabled(true) // TCP SACK is disabled by default
+	tcpipErr := dev.stack.SetTransportProtocolOption(tcp.ProtocolNumber, &sackEnabledOpt)
+	if tcpipErr != nil {
+		return nil, nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
+	}
+	dev.ep.AddNotify(dev)
+	tcpipErr = dev.stack.CreateNIC(1, dev.ep)
+	if tcpipErr != nil {
+		return nil, nil, fmt.Errorf("CreateNIC: %v", tcpipErr)
+	}
+	for _, ip := range localAddresses {
+		var protoNumber tcpip.NetworkProtocolNumber
+		if ip.Is4() {
+			protoNumber = ipv4.ProtocolNumber
+		} else if ip.Is6() {
+			protoNumber = ipv6.ProtocolNumber
+		}
+		protoAddr := tcpip.ProtocolAddress{
+			Protocol:          protoNumber,
+			AddressWithPrefix: tcpip.AddrFromSlice(ip.AsSlice()).WithPrefix(),
+		}
+		tcpipErr := dev.stack.AddProtocolAddress(1, protoAddr, stack.AddressProperties{})
+		if tcpipErr != nil {
+			return nil, nil, fmt.Errorf("AddProtocolAddress(%v): %v", ip, tcpipErr)
+		}
+		if ip.Is4() {
+			dev.hasV4 = true
+		} else if ip.Is6() {
+			dev.hasV6 = true
+		}
+	}
+	if dev.hasV4 {
+		dev.stack.AddRoute(tcpip.Route{Destination: header.IPv4EmptySubnet, NIC: 1})
+	}
+	if dev.hasV6 {
+		dev.stack.AddRoute(tcpip.Route{Destination: header.IPv6EmptySubnet, NIC: 1})
+	}
+
+	dev.events <- tun.EventUp
+	return dev, (*Net)(dev), nil
+}
+
+func (tun *netTun) Name() (string, error) {
+	return "go", nil
+}
+
+func (tun *netTun) File() *os.File {
+	return nil
+}
+
+func (tun *netTun) Events() <-chan tun.Event {
+	return tun.events
+}
+
+func (tun *netTun) Read(buf [][]byte, sizes []int, offset int) (int, error) {
+	view, ok := <-tun.incomingPacket
+	if !ok {
+		return 0, os.ErrClosed
+	}
+
+	n, err := view.Read(buf[0][offset:])
+	if err != nil {
+		return 0, err
+	}
+	sizes[0] = n
+	return 1, nil
+}
+
+func (tun *netTun) Write(buf [][]byte, offset int) (int, error) {
+	for _, buf := range buf {
+		packet := buf[offset:]
+		if len(packet) == 0 {
+			continue
+		}
+
+		pkb := stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buffer.MakeWithData(packet)})
+		switch packet[0] >> 4 {
+		case 4:
+			tun.ep.InjectInbound(header.IPv4ProtocolNumber, pkb)
+		case 6:
+			tun.ep.InjectInbound(header.IPv6ProtocolNumber, pkb)
+		default:
+			return 0, syscall.EAFNOSUPPORT
+		}
+	}
+	return len(buf), nil
+}
+
+func (tun *netTun) WriteNotify() {
+	pkt := tun.ep.Read()
+	if pkt.IsNil() {
+		return
+	}
+
+	view := pkt.ToView()
+	pkt.DecRef()
+
+	tun.incomingPacket <- view
+}
+
+func (tun *netTun) Close() error {
+	tun.stack.RemoveNIC(1)
+
+	if tun.events != nil {
+		close(tun.events)
+	}
+
+	tun.ep.Close()
+
+	if tun.incomingPacket != nil {
+		close(tun.incomingPacket)
+	}
+
+	return nil
+}
+
+func (tun *netTun) MTU() (int, error) {
+	return tun.mtu, nil
+}
+
+func (tun *netTun) BatchSize() int {
+	return 1
+}
+
+func convertToFullAddr(endpoint netip.AddrPort) (tcpip.FullAddress, tcpip.NetworkProtocolNumber) {
+	var protoNumber tcpip.NetworkProtocolNumber
+	if endpoint.Addr().Is4() {
+		protoNumber = ipv4.ProtocolNumber
+	} else {
+		protoNumber = ipv6.ProtocolNumber
+	}
+	return tcpip.FullAddress{
+		NIC:  1,
+		Addr: tcpip.AddrFromSlice(endpoint.Addr().AsSlice()),
+		Port: endpoint.Port(),
+	}, protoNumber
+}
+
+func (net *Net) DialContextTCPAddrPort(ctx context.Context, addr netip.AddrPort) (*gonet.TCPConn, error) {
+	fa, pn := convertToFullAddr(addr)
+	return gonet.DialContextTCP(ctx, net.stack, fa, pn)
+}
+
+func (net *Net) DialContextTCP(ctx context.Context, addr *net.TCPAddr) (*gonet.TCPConn, error) {
+	if addr == nil {
+		return net.DialContextTCPAddrPort(ctx, netip.AddrPort{})
+	}
+	ip, _ := netip.AddrFromSlice(addr.IP)
+	return net.DialContextTCPAddrPort(ctx, netip.AddrPortFrom(ip, uint16(addr.Port)))
+}
+
+func (net *Net) DialTCPAddrPort(addr netip.AddrPort) (*gonet.TCPConn, error) {
+	fa, pn := convertToFullAddr(addr)
+	return gonet.DialTCP(net.stack, fa, pn)
+}
+
+func (net *Net) DialTCP(addr *net.TCPAddr) (*gonet.TCPConn, error) {
+	if addr == nil {
+		return net.DialTCPAddrPort(netip.AddrPort{})
+	}
+	ip, _ := netip.AddrFromSlice(addr.IP)
+	return net.DialTCPAddrPort(netip.AddrPortFrom(ip, uint16(addr.Port)))
+}
+
+func (net *Net) ListenTCPAddrPort(addr netip.AddrPort) (*gonet.TCPListener, error) {
+	fa, pn := convertToFullAddr(addr)
+	return gonet.ListenTCP(net.stack, fa, pn)
+}
+
+func (net *Net) ListenTCP(addr *net.TCPAddr) (*gonet.TCPListener, error) {
+	if addr == nil {
+		return net.ListenTCPAddrPort(netip.AddrPort{})
+	}
+	ip, _ := netip.AddrFromSlice(addr.IP)
+	return net.ListenTCPAddrPort(netip.AddrPortFrom(ip, uint16(addr.Port)))
+}
+
+func (net *Net) DialUDPAddrPort(laddr, raddr netip.AddrPort) (*gonet.UDPConn, error) {
+	var lfa, rfa *tcpip.FullAddress
+	var pn tcpip.NetworkProtocolNumber
+	if laddr.IsValid() || laddr.Port() > 0 {
+		var addr tcpip.FullAddress
+		addr, pn = convertToFullAddr(laddr)
+		lfa = &addr
+	}
+	if raddr.IsValid() || raddr.Port() > 0 {
+		var addr tcpip.FullAddress
+		addr, pn = convertToFullAddr(raddr)
+		rfa = &addr
+	}
+	return gonet.DialUDP(net.stack, lfa, rfa, pn)
+}
+
+func (net *Net) ListenUDPAddrPort(laddr netip.AddrPort) (*gonet.UDPConn, error) {
+	return net.DialUDPAddrPort(laddr, netip.AddrPort{})
+}
+
+func (net *Net) DialUDP(laddr, raddr *net.UDPAddr) (*gonet.UDPConn, error) {
+	var la, ra netip.AddrPort
+	if laddr != nil {
+		ip, _ := netip.AddrFromSlice(laddr.IP)
+		la = netip.AddrPortFrom(ip, uint16(laddr.Port))
+	}
+	if raddr != nil {
+		ip, _ := netip.AddrFromSlice(raddr.IP)
+		ra = netip.AddrPortFrom(ip, uint16(raddr.Port))
+	}
+	return net.DialUDPAddrPort(la, ra)
+}
+
+func (net *Net) ListenUDP(laddr *net.UDPAddr) (*gonet.UDPConn, error) {
+	return net.DialUDP(laddr, nil)
+}
+
+type PingConn struct {
+	laddr    PingAddr
+	raddr    PingAddr
+	wq       waiter.Queue
+	ep       tcpip.Endpoint
+	deadline *time.Timer
+}
+
+type PingAddr struct{ addr netip.Addr }
+
+func (ia PingAddr) String() string {
+	return ia.addr.String()
+}
+
+func (ia PingAddr) Network() string {
+	if ia.addr.Is4() {
+		return "ping4"
+	} else if ia.addr.Is6() {
+		return "ping6"
+	}
+	return "ping"
+}
+
+func (ia PingAddr) Addr() netip.Addr {
+	return ia.addr
+}
+
+func PingAddrFromAddr(addr netip.Addr) *PingAddr {
+	return &PingAddr{addr}
+}
+
+func (net *Net) DialPingAddr(laddr, raddr netip.Addr) (*PingConn, error) {
+	if !laddr.IsValid() && !raddr.IsValid() {
+		return nil, errors.New("ping dial: invalid address")
+	}
+	v6 := laddr.Is6() || raddr.Is6()
+	bind := laddr.IsValid()
+	if !bind {
+		if v6 {
+			laddr = netip.IPv6Unspecified()
+		} else {
+			laddr = netip.IPv4Unspecified()
+		}
+	}
+
+	tn := icmp.ProtocolNumber4
+	pn := ipv4.ProtocolNumber
+	if v6 {
+		tn = icmp.ProtocolNumber6
+		pn = ipv6.ProtocolNumber
+	}
+
+	pc := &PingConn{
+		laddr:    PingAddr{laddr},
+		deadline: time.NewTimer(time.Hour << 10),
+	}
+	pc.deadline.Stop()
+
+	ep, tcpipErr := net.stack.NewEndpoint(tn, pn, &pc.wq)
+	if tcpipErr != nil {
+		return nil, fmt.Errorf("ping socket: endpoint: %s", tcpipErr)
+	}
+	pc.ep = ep
+
+	if bind {
+		fa, _ := convertToFullAddr(netip.AddrPortFrom(laddr, 0))
+		if tcpipErr = pc.ep.Bind(fa); tcpipErr != nil {
+			return nil, fmt.Errorf("ping bind: %s", tcpipErr)
+		}
+	}
+
+	if raddr.IsValid() {
+		pc.raddr = PingAddr{raddr}
+		fa, _ := convertToFullAddr(netip.AddrPortFrom(raddr, 0))
+		if tcpipErr = pc.ep.Connect(fa); tcpipErr != nil {
+			return nil, fmt.Errorf("ping connect: %s", tcpipErr)
+		}
+	}
+
+	return pc, nil
+}
+
+func (net *Net) ListenPingAddr(laddr netip.Addr) (*PingConn, error) {
+	return net.DialPingAddr(laddr, netip.Addr{})
+}
+
+func (net *Net) DialPing(laddr, raddr *PingAddr) (*PingConn, error) {
+	var la, ra netip.Addr
+	if laddr != nil {
+		la = laddr.addr
+	}
+	if raddr != nil {
+		ra = raddr.addr
+	}
+	return net.DialPingAddr(la, ra)
+}
+
+func (net *Net) ListenPing(laddr *PingAddr) (*PingConn, error) {
+	var la netip.Addr
+	if laddr != nil {
+		la = laddr.addr
+	}
+	return net.ListenPingAddr(la)
+}
+
+func (pc *PingConn) LocalAddr() net.Addr {
+	return pc.laddr
+}
+
+func (pc *PingConn) RemoteAddr() net.Addr {
+	return pc.raddr
+}
+
+func (pc *PingConn) Close() error {
+	pc.deadline.Reset(0)
+	pc.ep.Close()
+	return nil
+}
+
+func (pc *PingConn) SetWriteDeadline(t time.Time) error {
+	return errors.New("not implemented")
+}
+
+func (pc *PingConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	var na netip.Addr
+	switch v := addr.(type) {
+	case *PingAddr:
+		na = v.addr
+	case *net.IPAddr:
+		na, _ = netip.AddrFromSlice(v.IP)
+	default:
+		return 0, fmt.Errorf("ping write: wrong net.Addr type")
+	}
+	if !((na.Is4() && pc.laddr.addr.Is4()) || (na.Is6() && pc.laddr.addr.Is6())) {
+		return 0, fmt.Errorf("ping write: mismatched protocols")
+	}
+
+	buf := bytes.NewReader(p)
+	rfa, _ := convertToFullAddr(netip.AddrPortFrom(na, 0))
+	// won't block, no deadlines
+	n64, tcpipErr := pc.ep.Write(buf, tcpip.WriteOptions{
+		To: &rfa,
+	})
+	if tcpipErr != nil {
+		return int(n64), fmt.Errorf("ping write: %s", tcpipErr)
+	}
+
+	return int(n64), nil
+}
+
+func (pc *PingConn) Write(p []byte) (n int, err error) {
+	return pc.WriteTo(p, &pc.raddr)
+}
+
+func (pc *PingConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	e, notifyCh := waiter.NewChannelEntry(waiter.EventIn)
+	pc.wq.EventRegister(&e)
+	defer pc.wq.EventUnregister(&e)
+
+	select {
+	case <-pc.deadline.C:
+		return 0, nil, os.ErrDeadlineExceeded
+	case <-notifyCh:
+	}
+
+	w := tcpip.SliceWriter(p)
+
+	res, tcpipErr := pc.ep.Read(&w, tcpip.ReadOptions{
+		NeedRemoteAddr: true,
+	})
+	if tcpipErr != nil {
+		return 0, nil, fmt.Errorf("ping read: %s", tcpipErr)
+	}
+
+	remoteAddr, _ := netip.AddrFromSlice(res.RemoteAddr.Addr.AsSlice())
+	return res.Count, &PingAddr{remoteAddr}, nil
+}
+
+func (pc *PingConn) Read(p []byte) (n int, err error) {
+	n, _, err = pc.ReadFrom(p)
+	return
+}
+
+func (pc *PingConn) SetDeadline(t time.Time) error {
+	// pc.SetWriteDeadline is unimplemented
+
+	return pc.SetReadDeadline(t)
+}
+
+func (pc *PingConn) SetReadDeadline(t time.Time) error {
+	pc.deadline.Reset(time.Until(t))
+	return nil
+}
+
+var (
+	errNoSuchHost                   = errors.New("no such host")
+	errLameReferral                 = errors.New("lame referral")
+	errCannotUnmarshalDNSMessage    = errors.New("cannot unmarshal DNS message")
+	errCannotMarshalDNSMessage      = errors.New("cannot marshal DNS message")
+	errServerMisbehaving            = errors.New("server misbehaving")
+	errInvalidDNSResponse           = errors.New("invalid DNS response")
+	errNoAnswerFromDNSServer        = errors.New("no answer from DNS server")
+	errServerTemporarilyMisbehaving = errors.New("server misbehaving")
+	errCanceled                     = errors.New("operation was canceled")
+	errTimeout                      = errors.New("i/o timeout")
+	errNumericPort                  = errors.New("port must be numeric")
+	errNoSuitableAddress            = errors.New("no suitable address found")
+	errMissingAddress               = errors.New("missing address")
+)
+
+func (net *Net) LookupHost(host string) (addrs []string, err error) {
+	return net.LookupContextHost(context.Background(), host)
+}
+
+func isDomainName(s string) bool {
+	l := len(s)
+	if l == 0 || l > 254 || l == 254 && s[l-1] != '.' {
+		return false
+	}
+	last := byte('.')
+	nonNumeric := false
+	partlen := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		default:
+			return false
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_':
+			nonNumeric = true
+			partlen++
+		case '0' <= c && c <= '9':
+			partlen++
+		case c == '-':
+			if last == '.' {
+				return false
+			}
+			partlen++
+			nonNumeric = true
+		case c == '.':
+			if last == '.' || last == '-' {
+				return false
+			}
+			if partlen > 63 || partlen == 0 {
+				return false
+			}
+			partlen = 0
+		}
+		last = c
+	}
+	if last == '-' || partlen > 63 {
+		return false
+	}
+	return nonNumeric
+}
+
+func randU16() uint16 {
+	var b [2]byte
+	_, err := rand.Read(b[:])
+	if err != nil {
+		panic(err)
+	}
+	return binary.LittleEndian.Uint16(b[:])
+}
+
+func newRequest(q dnsmessage.Question) (id uint16, udpReq, tcpReq []byte, err error) {
+	id = randU16()
+	b := dnsmessage.NewBuilder(make([]byte, 2, 514), dnsmessage.Header{ID: id, RecursionDesired: true})
+	b.EnableCompression()
+	if err := b.StartQuestions(); err != nil {
+		return 0, nil, nil, err
+	}
+	if err := b.Question(q); err != nil {
+		return 0, nil, nil, err
+	}
+	tcpReq, err = b.Finish()
+	udpReq = tcpReq[2:]
+	l := len(tcpReq) - 2
+	tcpReq[0] = byte(l >> 8)
+	tcpReq[1] = byte(l)
+	return id, udpReq, tcpReq, err
+}
+
+func equalASCIIName(x, y dnsmessage.Name) bool {
+	if x.Length != y.Length {
+		return false
+	}
+	for i := 0; i < int(x.Length); i++ {
+		a := x.Data[i]
+		b := y.Data[i]
+		if 'A' <= a && a <= 'Z' {
+			a += 0x20
+		}
+		if 'A' <= b && b <= 'Z' {
+			b += 0x20
+		}
+		if a != b {
+			return false
+		}
+	}
+	return true
+}
+
+func checkResponse(reqID uint16, reqQues dnsmessage.Question, respHdr dnsmessage.Header, respQues dnsmessage.Question) bool {
+	if !respHdr.Response {
+		return false
+	}
+	if reqID != respHdr.ID {
+		return false
+	}
+	if reqQues.Type != respQues.Type || reqQues.Class != respQues.Class || !equalASCIIName(reqQues.Name, respQues.Name) {
+		return false
+	}
+	return true
+}
+
+func dnsPacketRoundTrip(c net.Conn, id uint16, query dnsmessage.Question, b []byte) (dnsmessage.Parser, dnsmessage.Header, error) {
+	if _, err := c.Write(b); err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, err
+	}
+	b = make([]byte, 512)
+	for {
+		n, err := c.Read(b)
+		if err != nil {
+			return dnsmessage.Parser{}, dnsmessage.Header{}, err
+		}
+		var p dnsmessage.Parser
+		h, err := p.Start(b[:n])
+		if err != nil {
+			continue
+		}
+		q, err := p.Question()
+		if err != nil || !checkResponse(id, query, h, q) {
+			continue
+		}
+		return p, h, nil
+	}
+}
+
+func dnsStreamRoundTrip(c net.Conn, id uint16, query dnsmessage.Question, b []byte) (dnsmessage.Parser, dnsmessage.Header, error) {
+	if _, err := c.Write(b); err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, err
+	}
+	b = make([]byte, 1280)
+	if _, err := io.ReadFull(c, b[:2]); err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, err
+	}
+	l := int(b[0])<<8 | int(b[1])
+	if l > len(b) {
+		b = make([]byte, l)
+	}
+	n, err := io.ReadFull(c, b[:l])
+	if err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, err
+	}
+	var p dnsmessage.Parser
+	h, err := p.Start(b[:n])
+	if err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, errCannotUnmarshalDNSMessage
+	}
+	q, err := p.Question()
+	if err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, errCannotUnmarshalDNSMessage
+	}
+	if !checkResponse(id, query, h, q) {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, errInvalidDNSResponse
+	}
+	return p, h, nil
+}
+
+func (tnet *Net) exchange(ctx context.Context, server netip.Addr, q dnsmessage.Question, timeout time.Duration) (dnsmessage.Parser, dnsmessage.Header, error) {
+	q.Class = dnsmessage.ClassINET
+	id, udpReq, tcpReq, err := newRequest(q)
+	if err != nil {
+		return dnsmessage.Parser{}, dnsmessage.Header{}, errCannotMarshalDNSMessage
+	}
+
+	for _, useUDP := range []bool{true, false} {
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
+		defer cancel()
+
+		var c net.Conn
+		var err error
+		if useUDP {
+			c, err = tnet.DialUDPAddrPort(netip.AddrPort{}, netip.AddrPortFrom(server, 53))
+		} else {
+			c, err = tnet.DialContextTCPAddrPort(ctx, netip.AddrPortFrom(server, 53))
+		}
+
+		if err != nil {
+			return dnsmessage.Parser{}, dnsmessage.Header{}, err
+		}
+		if d, ok := ctx.Deadline(); ok && !d.IsZero() {
+			err := c.SetDeadline(d)
+			if err != nil {
+				return dnsmessage.Parser{}, dnsmessage.Header{}, err
+			}
+		}
+		var p dnsmessage.Parser
+		var h dnsmessage.Header
+		if useUDP {
+			p, h, err = dnsPacketRoundTrip(c, id, q, udpReq)
+		} else {
+			p, h, err = dnsStreamRoundTrip(c, id, q, tcpReq)
+		}
+		c.Close()
+		if err != nil {
+			if err == context.Canceled {
+				err = errCanceled
+			} else if err == context.DeadlineExceeded {
+				err = errTimeout
+			}
+			return dnsmessage.Parser{}, dnsmessage.Header{}, err
+		}
+		if err := p.SkipQuestion(); err != dnsmessage.ErrSectionDone {
+			return dnsmessage.Parser{}, dnsmessage.Header{}, errInvalidDNSResponse
+		}
+		if h.Truncated {
+			continue
+		}
+		return p, h, nil
+	}
+	return dnsmessage.Parser{}, dnsmessage.Header{}, errNoAnswerFromDNSServer
+}
+
+func checkHeader(p *dnsmessage.Parser, h dnsmessage.Header) error {
+	if h.RCode == dnsmessage.RCodeNameError {
+		return errNoSuchHost
+	}
+	_, err := p.AnswerHeader()
+	if err != nil && err != dnsmessage.ErrSectionDone {
+		return errCannotUnmarshalDNSMessage
+	}
+	if h.RCode == dnsmessage.RCodeSuccess && !h.Authoritative && !h.RecursionAvailable && err == dnsmessage.ErrSectionDone {
+		return errLameReferral
+	}
+	if h.RCode != dnsmessage.RCodeSuccess && h.RCode != dnsmessage.RCodeNameError {
+		if h.RCode == dnsmessage.RCodeServerFailure {
+			return errServerTemporarilyMisbehaving
+		}
+		return errServerMisbehaving
+	}
+	return nil
+}
+
+func skipToAnswer(p *dnsmessage.Parser, qtype dnsmessage.Type) error {
+	for {
+		h, err := p.AnswerHeader()
+		if err == dnsmessage.ErrSectionDone {
+			return errNoSuchHost
+		}
+		if err != nil {
+			return errCannotUnmarshalDNSMessage
+		}
+		if h.Type == qtype {
+			return nil
+		}
+		if err := p.SkipAnswer(); err != nil {
+			return errCannotUnmarshalDNSMessage
+		}
+	}
+}
+
+func (tnet *Net) tryOneName(ctx context.Context, name string, qtype dnsmessage.Type) (dnsmessage.Parser, string, error) {
+	var lastErr error
+
+	n, err := dnsmessage.NewName(name)
+	if err != nil {
+		return dnsmessage.Parser{}, "", errCannotMarshalDNSMessage
+	}
+	q := dnsmessage.Question{
+		Name:  n,
+		Type:  qtype,
+		Class: dnsmessage.ClassINET,
+	}
+
+	for i := 0; i < 2; i++ {
+		for _, server := range tnet.dnsServers {
+			p, h, err := tnet.exchange(ctx, server, q, time.Second*5)
+			if err != nil {
+				dnsErr := &net.DNSError{
+					Err:    err.Error(),
+					Name:   name,
+					Server: server.String(),
+				}
+				if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+					dnsErr.IsTimeout = true
+				}
+				if _, ok := err.(*net.OpError); ok {
+					dnsErr.IsTemporary = true
+				}
+				lastErr = dnsErr
+				continue
+			}
+
+			if err := checkHeader(&p, h); err != nil {
+				dnsErr := &net.DNSError{
+					Err:    err.Error(),
+					Name:   name,
+					Server: server.String(),
+				}
+				if err == errServerTemporarilyMisbehaving {
+					dnsErr.IsTemporary = true
+				}
+				if err == errNoSuchHost {
+					dnsErr.IsNotFound = true
+					return p, server.String(), dnsErr
+				}
+				lastErr = dnsErr
+				continue
+			}
+
+			err = skipToAnswer(&p, qtype)
+			if err == nil {
+				return p, server.String(), nil
+			}
+			lastErr = &net.DNSError{
+				Err:    err.Error(),
+				Name:   name,
+				Server: server.String(),
+			}
+			if err == errNoSuchHost {
+				lastErr.(*net.DNSError).IsNotFound = true
+				return p, server.String(), lastErr
+			}
+		}
+	}
+	return dnsmessage.Parser{}, "", lastErr
+}
+
+func (tnet *Net) LookupContextHost(ctx context.Context, host string) ([]string, error) {
+	if host == "" || (!tnet.hasV6 && !tnet.hasV4) {
+		return nil, &net.DNSError{Err: errNoSuchHost.Error(), Name: host, IsNotFound: true}
+	}
+	zlen := len(host)
+	if strings.IndexByte(host, ':') != -1 {
+		if zidx := strings.LastIndexByte(host, '%'); zidx != -1 {
+			zlen = zidx
+		}
+	}
+	if ip, err := netip.ParseAddr(host[:zlen]); err == nil {
+		return []string{ip.String()}, nil
+	}
+
+	if !isDomainName(host) {
+		return nil, &net.DNSError{Err: errNoSuchHost.Error(), Name: host, IsNotFound: true}
+	}
+	type result struct {
+		p      dnsmessage.Parser
+		server string
+		error
+	}
+	var addrsV4, addrsV6 []netip.Addr
+	lanes := 0
+	if tnet.hasV4 {
+		lanes++
+	}
+	if tnet.hasV6 {
+		lanes++
+	}
+	lane := make(chan result, lanes)
+	var lastErr error
+	if tnet.hasV4 {
+		go func() {
+			p, server, err := tnet.tryOneName(ctx, host+".", dnsmessage.TypeA)
+			lane <- result{p, server, err}
+		}()
+	}
+	if tnet.hasV6 {
+		go func() {
+			p, server, err := tnet.tryOneName(ctx, host+".", dnsmessage.TypeAAAA)
+			lane <- result{p, server, err}
+		}()
+	}
+	for l := 0; l < lanes; l++ {
+		result := <-lane
+		if result.error != nil {
+			if lastErr == nil {
+				lastErr = result.error
+			}
+			continue
+		}
+
+	loop:
+		for {
+			h, err := result.p.AnswerHeader()
+			if err != nil && err != dnsmessage.ErrSectionDone {
+				lastErr = &net.DNSError{
+					Err:    errCannotMarshalDNSMessage.Error(),
+					Name:   host,
+					Server: result.server,
+				}
+			}
+			if err != nil {
+				break
+			}
+			switch h.Type {
+			case dnsmessage.TypeA:
+				a, err := result.p.AResource()
+				if err != nil {
+					lastErr = &net.DNSError{
+						Err:    errCannotMarshalDNSMessage.Error(),
+						Name:   host,
+						Server: result.server,
+					}
+					break loop
+				}
+				addrsV4 = append(addrsV4, netip.AddrFrom4(a.A))
+
+			case dnsmessage.TypeAAAA:
+				aaaa, err := result.p.AAAAResource()
+				if err != nil {
+					lastErr = &net.DNSError{
+						Err:    errCannotMarshalDNSMessage.Error(),
+						Name:   host,
+						Server: result.server,
+					}
+					break loop
+				}
+				addrsV6 = append(addrsV6, netip.AddrFrom16(aaaa.AAAA))
+
+			default:
+				if err := result.p.SkipAnswer(); err != nil {
+					lastErr = &net.DNSError{
+						Err:    errCannotMarshalDNSMessage.Error(),
+						Name:   host,
+						Server: result.server,
+					}
+					break loop
+				}
+				continue
+			}
+		}
+	}
+	// We don't do RFC6724. Instead just put V6 addresses first if an IPv6 address is enabled
+	var addrs []netip.Addr
+	if tnet.hasV6 {
+		addrs = append(addrsV6, addrsV4...)
+	} else {
+		addrs = append(addrsV4, addrsV6...)
+	}
+
+	if len(addrs) == 0 && lastErr != nil {
+		return nil, lastErr
+	}
+	saddrs := make([]string, 0, len(addrs))
+	for _, ip := range addrs {
+		saddrs = append(saddrs, ip.String())
+	}
+	return saddrs, nil
+}
+
+func partialDeadline(now, deadline time.Time, addrsRemaining int) (time.Time, error) {
+	if deadline.IsZero() {
+		return deadline, nil
+	}
+	timeRemaining := deadline.Sub(now)
+	if timeRemaining <= 0 {
+		return time.Time{}, errTimeout
+	}
+	timeout := timeRemaining / time.Duration(addrsRemaining)
+	const saneMinimum = 2 * time.Second
+	if timeout < saneMinimum {
+		if timeRemaining < saneMinimum {
+			timeout = timeRemaining
+		} else {
+			timeout = saneMinimum
+		}
+	}
+	return now.Add(timeout), nil
+}
+
+var protoSplitter = regexp.MustCompile(`^(tcp|udp|ping)(4|6)?$`)
+
+func (tnet *Net) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if ctx == nil {
+		panic("nil context")
+	}
+	var acceptV4, acceptV6 bool
+	matches := protoSplitter.FindStringSubmatch(network)
+	if matches == nil {
+		return nil, &net.OpError{Op: "dial", Err: net.UnknownNetworkError(network)}
+	} else if len(matches[2]) == 0 {
+		acceptV4 = true
+		acceptV6 = true
+	} else {
+		acceptV4 = matches[2][0] == '4'
+		acceptV6 = !acceptV4
+	}
+	var host string
+	var port int
+	if matches[1] == "ping" {
+		host = address
+	} else {
+		var sport string
+		var err error
+		host, sport, err = net.SplitHostPort(address)
+		if err != nil {
+			return nil, &net.OpError{Op: "dial", Err: err}
+		}
+		port, err = strconv.Atoi(sport)
+		if err != nil || port < 0 || port > 65535 {
+			return nil, &net.OpError{Op: "dial", Err: errNumericPort}
+		}
+	}
+	allAddr, err := tnet.LookupContextHost(ctx, host)
+	if err != nil {
+		return nil, &net.OpError{Op: "dial", Err: err}
+	}
+	var addrs []netip.AddrPort
+	for _, addr := range allAddr {
+		ip, err := netip.ParseAddr(addr)
+		if err == nil && ((ip.Is4() && acceptV4) || (ip.Is6() && acceptV6)) {
+			addrs = append(addrs, netip.AddrPortFrom(ip, uint16(port)))
+		}
+	}
+	if len(addrs) == 0 && len(allAddr) != 0 {
+		return nil, &net.OpError{Op: "dial", Err: errNoSuitableAddress}
+	}
+
+	var firstErr error
+	for i, addr := range addrs {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			if err == context.Canceled {
+				err = errCanceled
+			} else if err == context.DeadlineExceeded {
+				err = errTimeout
+			}
+			return nil, &net.OpError{Op: "dial", Err: err}
+		default:
+		}
+
+		dialCtx := ctx
+		if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
+			partialDeadline, err := partialDeadline(time.Now(), deadline, len(addrs)-i)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = &net.OpError{Op: "dial", Err: err}
+				}
+				break
+			}
+			if partialDeadline.Before(deadline) {
+				var cancel context.CancelFunc
+				dialCtx, cancel = context.WithDeadline(ctx, partialDeadline)
+				defer cancel()
+			}
+		}
+
+		var c net.Conn
+		switch matches[1] {
+		case "tcp":
+			c, err = tnet.DialContextTCPAddrPort(dialCtx, addr)
+		case "udp":
+			c, err = tnet.DialUDPAddrPort(netip.AddrPort{}, addr)
+		case "ping":
+			c, err = tnet.DialPingAddr(netip.Addr{}, addr.Addr())
+		}
+		if err == nil {
+			return c, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil {
+		firstErr = &net.OpError{Op: "dial", Err: errMissingAddress}
+	}
+	return nil, firstErr
+}
+
+func (tnet *Net) Dial(network, address string) (net.Conn, error) {
+	return tnet.DialContext(context.Background(), network, address)
+}

--- a/netstack/tun_extra.go
+++ b/netstack/tun_extra.go
@@ -1,0 +1,16 @@
+package netstack
+
+import (
+	"fmt"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+func (tun *Net) AddProtocolAddress(protoAddr tcpip.ProtocolAddress) error {
+	tcpipErr := tun.stack.AddProtocolAddress(1, protoAddr, stack.AddressProperties{})
+	if tcpipErr != nil {
+		return fmt.Errorf("AddProtocolAddress(%v): %v", protoAddr.AddressWithPrefix, tcpipErr)
+	}
+	return nil
+}

--- a/package.nix
+++ b/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   CGO_ENABLED = "0";
 
-  vendorHash = "sha256-xYJB8LxXnic8IoWmbtxrIH8p/TjjNo+kJMNFNvaNPbY=";
+  vendorHash = "sha256-aDh2f0LCcBR31mwXVusyItqoneQkJi1fuckY/V7Qxy8=";
 
   ldflags = [ "-s" "-w" "-X github.com/hyprspace/hyprspace/cli.appVersion=${version}" ];
 

--- a/svc/network.go
+++ b/svc/network.go
@@ -1,0 +1,115 @@
+package svc
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/hyprspace/hyprspace/netstack"
+	hstun "github.com/hyprspace/hyprspace/tun"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"golang.zx2c4.com/wireguard/tun"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+)
+
+type ServiceNetwork struct {
+	self         peer.ID
+	NetworkRange net.IPNet
+	Tun          *tun.Device
+	netx         *netstack.Net
+	activeAddrs  map[[16]byte]struct{}
+	activePorts  map[[16]byte]map[uint16]struct{}
+	listeners    map[[6]byte]func(net.Listener) error
+}
+
+func (sn *ServiceNetwork) Register(addr net.IP, serveFunc func(net.Listener) error) {
+	var svcId [6]byte = [6]byte(addr[10:16])
+	sn.listeners[svcId] = serveFunc
+}
+
+func (sn *ServiceNetwork) EnsureListener(addr [16]byte, port uint16) bool {
+	registerAddr := true
+	if _, ok := sn.activeAddrs[addr]; ok {
+		if _, ok := sn.activePorts[addr][port]; ok {
+			return true
+		}
+		registerAddr = false
+	}
+	var serveFunc func(net.Listener) error
+	if s, ok := sn.listeners[[6]byte(addr[10:16])]; ok {
+		serveFunc = s
+	} else {
+		fmt.Printf("[!] [svc] Unknown service: %x\n", addr[10:16])
+		return false
+	}
+	tcpAddr := net.TCPAddr{
+		IP:   net.IP(addr[:]),
+		Port: int(port),
+	}
+	if registerAddr {
+		fmt.Printf("[-] [svc] Registering /ip6/%s\n", tcpAddr.IP)
+		sn.netx.AddProtocolAddress(tcpip.ProtocolAddress{
+			Protocol:          ipv6.ProtocolNumber,
+			AddressWithPrefix: tcpip.AddrFrom16(addr).WithPrefix(),
+		})
+		sn.activeAddrs[addr] = struct{}{}
+		sn.activePorts[addr] = make(map[uint16]struct{})
+	}
+
+	tcpL, err := sn.netx.ListenTCP(&tcpAddr)
+	sn.activePorts[addr][port] = struct{}{}
+	if err != nil {
+		panic(err)
+	}
+
+	go serveFunc(tcpL)
+	fmt.Printf("[-] [svc] Listening on /ip6/%s/tcp/%d\n", tcpAddr.IP, tcpAddr.Port)
+	return true
+}
+
+func NewServiceNetwork(p peer.ID, tunDev *hstun.TUN) ServiceNetwork {
+	tun, netx, err := netstack.CreateNetTUN(
+		[]netip.Addr{
+			netip.AddrFrom16([16]byte([]byte("\xfd\x00hyprspinternal"))),
+		},
+		[]netip.Addr{},
+		1420,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+		sizes := make([]int, 1)
+		buffer := make([]byte, 1420)
+		buffers := make([][]byte, 1)
+		buffers[0] = buffer
+		for {
+			count, err := tun.Read(buffers, sizes, 0)
+			if err != nil {
+				panic(err)
+			}
+			if count == 1 {
+				_, err := tunDev.Iface.Write(buffers[0])
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	}()
+
+	fmt.Println("[+] Service Network ready")
+	return ServiceNetwork{
+		self: p,
+		NetworkRange: net.IPNet{
+			IP:   []byte("\xfd\x00hyprspsv\x00\x00\x00\x00\x00\x00"),
+			Mask: net.CIDRMask(80, 128),
+		},
+		Tun:         &tun,
+		netx:        netx,
+		activeAddrs: make(map[[16]byte]struct{}),
+		activePorts: make(map[[16]byte]map[uint16]struct{}),
+		listeners:   make(map[[6]byte]func(net.Listener) error),
+	}
+}

--- a/svc/network.go
+++ b/svc/network.go
@@ -31,7 +31,7 @@ type ServiceNetwork struct {
 func (sn *ServiceNetwork) Register(serviceName string, proxy Proxy) {
 	svcId := config.MkServiceID(serviceName)
 	sn.listeners[svcId] = proxy
-	fmt.Printf("[-] Registered service \"%s\" [%x]\n", serviceName, svcId)
+	fmt.Printf("[-] Registered service \"%s\" [%x]: %s\n", serviceName, svcId, proxy.Description)
 }
 
 func (sn *ServiceNetwork) EnsureListener(addr [16]byte, port uint16) bool {

--- a/svc/network.go
+++ b/svc/network.go
@@ -114,7 +114,7 @@ func NewServiceNetwork(host host.Host, cfg *config.Config, tunDev *hstun.TUN) Se
 
 	fmt.Println("[+] Service Network ready")
 
-	return ServiceNetwork{
+	sn := ServiceNetwork{
 		host:   host,
 		config: cfg,
 		self:   [4]byte(cfg.BuiltinAddr6[12:16]),
@@ -128,4 +128,7 @@ func NewServiceNetwork(host host.Host, cfg *config.Config, tunDev *hstun.TUN) Se
 		activePorts: make(map[[16]byte]map[uint16]struct{}),
 		listeners:   make(map[[2]byte]Proxy),
 	}
+
+	host.SetStreamHandler(Protocol, sn.streamHandler())
+	return sn
 }

--- a/svc/pipe.go
+++ b/svc/pipe.go
@@ -1,0 +1,50 @@
+package svc
+
+type streamable interface {
+	Write([]byte) (int, error)
+	Read([]byte) (int, error)
+}
+
+func toChan(s streamable) chan []byte {
+	c := make(chan []byte)
+
+	go func() {
+		b := make([]byte, 1024)
+
+		for {
+			n, err := s.Read(b)
+			if n > 0 {
+				res := make([]byte, n)
+				copy(res, b[:n])
+				c <- res
+			}
+			if err != nil {
+				c <- nil
+				break
+			}
+		}
+	}()
+	return c
+}
+
+func pipe(s1 streamable, s2 streamable) {
+	chan1 := toChan(s1)
+	chan2 := toChan(s2)
+
+	for {
+		select {
+		case b1 := <-chan1:
+			if b1 == nil {
+				return
+			} else {
+				s2.Write(b1)
+			}
+		case b2 := <-chan2:
+			if b2 == nil {
+				return
+			} else {
+				s1.Write(b2)
+			}
+		}
+	}
+}

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -1,0 +1,53 @@
+package svc
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type RemoteServiceProxyStatus byte
+
+const (
+	RS_OK            RemoteServiceProxyStatus = 0xf1
+	RS_NOT_SUPPORTED RemoteServiceProxyStatus = 0xf2
+)
+
+func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) func(net.Listener) error {
+	return func(l net.Listener) error {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			go func() {
+				stream, err := host.NewStream(ctx, p, Protocol)
+				defer conn.Close()
+				if err != nil {
+					fmt.Printf("[!] [svc] %s\n", err)
+					return
+				}
+				defer stream.Close()
+				_, err = stream.Write(svcId[:])
+				if err != nil {
+					fmt.Printf("[!] [svc] %s\n", err)
+					return
+				}
+				buf := make([]byte, 1)
+				_, err = stream.Read(buf)
+				if err != nil {
+					fmt.Printf("[!] [svc] %s\n", err)
+					return
+				} else if buf[0] != byte(RS_OK) {
+					fmt.Printf("[!] [svc] Peer %s does not support service %x\n", p, svcId)
+					return
+				}
+				pipe(conn, stream)
+			}()
+		}
+	}
+}

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -9,6 +9,22 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+type Proxy struct {
+	Handle func(net.Conn)
+}
+
+func (p Proxy) ServeFunc() func(net.Listener) error {
+	return func(l net.Listener) error {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return err
+			}
+			go p.Handle(conn)
+		}
+	}
+}
+
 type RemoteServiceProxyStatus byte
 
 const (
@@ -16,38 +32,32 @@ const (
 	RS_NOT_SUPPORTED RemoteServiceProxyStatus = 0xf2
 )
 
-func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) func(net.Listener) error {
-	return func(l net.Listener) error {
-		for {
-			conn, err := l.Accept()
-			if err != nil {
-				return err
-			}
+func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) Proxy {
+	return Proxy{
+		Handle: func(conn net.Conn) {
 			ctx := context.Background()
-			go func() {
-				stream, err := host.NewStream(ctx, p, Protocol)
-				defer conn.Close()
-				if err != nil {
-					fmt.Printf("[!] [svc] %s\n", err)
-					return
-				}
-				defer stream.Close()
-				_, err = stream.Write(svcId[:])
-				if err != nil {
-					fmt.Printf("[!] [svc] %s\n", err)
-					return
-				}
-				buf := make([]byte, 1)
-				_, err = stream.Read(buf)
-				if err != nil {
-					fmt.Printf("[!] [svc] %s\n", err)
-					return
-				} else if buf[0] != byte(RS_OK) {
-					fmt.Printf("[!] [svc] Peer %s does not support service %x\n", p, svcId)
-					return
-				}
-				pipe(conn, stream)
-			}()
-		}
+			stream, err := host.NewStream(ctx, p, Protocol)
+			defer conn.Close()
+			if err != nil {
+				fmt.Printf("[!] [svc] %s\n", err)
+				return
+			}
+			defer stream.Close()
+			_, err = stream.Write(svcId[:])
+			if err != nil {
+				fmt.Printf("[!] [svc] %s\n", err)
+				return
+			}
+			buf := make([]byte, 1)
+			_, err = stream.Read(buf)
+			if err != nil {
+				fmt.Printf("[!] [svc] %s\n", err)
+				return
+			} else if buf[0] != byte(RS_OK) {
+				fmt.Printf("[!] [svc] Peer %s does not support service %x\n", p, svcId)
+				return
+			}
+			pipe(conn, stream)
+		},
 	}
 }

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -13,7 +13,8 @@ import (
 )
 
 type Proxy struct {
-	Handle func(net.Conn)
+	Handle      func(net.Conn)
+	Description string
 }
 
 func (p Proxy) ServeFunc() func(net.Listener) error {
@@ -98,6 +99,7 @@ func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) Proxy {
 			}
 			pipe(conn, stream)
 		},
+		Description: fmt.Sprintf("RemoteServiceProxy to service [%x] on %s", svcId, p),
 	}
 }
 
@@ -113,5 +115,6 @@ func TCPServiceProxy(tcpAddr net.TCPAddr) Proxy {
 			defer stream.Close()
 			pipe(conn, stream)
 		},
+		Description: fmt.Sprintf("TCPServiceProxy to %s", tcpAddr.AddrPort()),
 	}
 }

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -61,3 +61,18 @@ func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) Proxy {
 		},
 	}
 }
+
+func TCPServiceProxy(tcpAddr net.TCPAddr) Proxy {
+	return Proxy{
+		Handle: func(conn net.Conn) {
+			stream, err := net.DialTCP("tcp", nil, &tcpAddr)
+			defer conn.Close()
+			if err != nil {
+				fmt.Printf("[!] [svc] %s\n", err)
+				return
+			}
+			defer stream.Close()
+			pipe(conn, stream)
+		},
+	}
+}

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -2,11 +2,14 @@ package svc
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 )
 
 type Proxy struct {
@@ -23,6 +26,42 @@ func (p Proxy) ServeFunc() func(net.Listener) error {
 			go p.Handle(conn)
 		}
 	}
+}
+
+func ProxyTo(ma multiaddr.Multiaddr) (Proxy, error) {
+	var proxy Proxy
+
+	var err error
+	var done bool
+
+	var ipAddr net.IP = net.IPv4(127, 0, 0, 1)
+	var tcpPort uint16
+
+	multiaddr.ForEach(ma, func(c multiaddr.Component) bool {
+		if done {
+			err = errors.New("trailing components in address")
+			return false
+		}
+		switch c.Protocol().Code {
+		case multiaddr.P_IP4:
+			fallthrough
+		case multiaddr.P_IP6:
+			ipAddr = net.IP(c.RawValue())
+			return true
+		case multiaddr.P_TCP:
+			tcpPort = binary.BigEndian.Uint16(c.RawValue())
+			proxy = TCPServiceProxy(net.TCPAddr{
+				IP:   ipAddr,
+				Port: int(tcpPort),
+			})
+			done = true
+		default:
+			err = errors.New("unsupported protocol: " + c.Protocol().Name)
+			return false
+		}
+		return false
+	})
+	return proxy, err
 }
 
 type RemoteServiceProxyStatus byte

--- a/svc/receiver.go
+++ b/svc/receiver.go
@@ -1,0 +1,39 @@
+package svc
+
+import (
+	"fmt"
+	"github.com/hyprspace/hyprspace/config"
+	"github.com/libp2p/go-libp2p/core/network"
+)
+
+func (sn *ServiceNetwork) streamHandler() func(network.Stream) {
+	return func(stream network.Stream) {
+		if _, ok := config.FindPeer(sn.config.Peers, stream.Conn().RemotePeer()); !ok {
+			stream.Reset()
+			return
+		}
+		defer stream.Close()
+		buf := make([]byte, 2)
+		_, err := stream.Read(buf)
+		if err != nil {
+			fmt.Printf("[!] [svc] %s\n", err)
+			return
+		}
+		svcId := [2]byte(buf)
+		if proxy, ok := sn.listeners[svcId]; ok {
+			_, err := stream.Write([]byte{byte(RS_OK)})
+			if err != nil {
+				fmt.Printf("[!] [svc] %s\n", err)
+				return
+			}
+			proxy.Handle(WrapStream(stream))
+		} else {
+			fmt.Printf("[!] [svc] %s tried to connect to unknown service %x\n", stream.Conn().RemotePeer(), svcId)
+			_, err := stream.Write([]byte{byte(RS_NOT_SUPPORTED)})
+			if err != nil {
+				fmt.Printf("[!] [svc] %s\n", err)
+				return
+			}
+		}
+	}
+}

--- a/svc/wrapper.go
+++ b/svc/wrapper.go
@@ -1,0 +1,53 @@
+package svc
+
+import (
+	"net"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+)
+
+// dumb wrapper around network.Stream so it implements net.Conn
+type StreamWrapper struct {
+	Stream network.Stream
+}
+
+func WrapStream(s network.Stream) net.Conn {
+	return StreamWrapper{
+		Stream: s,
+	}
+}
+
+// does anything actually need these?
+func (sw StreamWrapper) LocalAddr() net.Addr {
+	panic("unimplemented")
+}
+
+func (sw StreamWrapper) RemoteAddr() net.Addr {
+	panic("unimplemented")
+}
+
+// everything else is already implemented
+func (sw StreamWrapper) Close() error {
+	return sw.Stream.Close()
+}
+
+func (sw StreamWrapper) Read(b []byte) (n int, err error) {
+	return sw.Stream.Read(b)
+}
+
+func (sw StreamWrapper) SetDeadline(t time.Time) error {
+	return sw.Stream.SetDeadline(t)
+}
+
+func (sw StreamWrapper) SetReadDeadline(t time.Time) error {
+	return sw.Stream.SetReadDeadline(t)
+}
+
+func (sw StreamWrapper) SetWriteDeadline(t time.Time) error {
+	return sw.Stream.SetWriteDeadline(t)
+}
+
+func (sw StreamWrapper) Write(b []byte) (n int, err error) {
+	return sw.Stream.Write(b)
+}


### PR DESCRIPTION
Depends on #14 

The service network is a completely virtual network inside the Hyprspace daemon, implemented using gVisor's userspace TCP/IP stack. The purpose is to be able to proxy services by name rather than by port (`example-web-service.mynode.hyprspace` instead of `mymode.hyprspace:8082`). We can also map TCP streams to libp2p streams directly, which should be more efficient than the stream reuse implementation used for individual packet forwarding.