### PR TITLE
Automatically gate addresses found in IPAddressDeny

### DIFF
--- a/cli/up.go
+++ b/cli/up.go
@@ -119,7 +119,10 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 		cfg.ListenAddresses,
 		streamHandler,
 		p2p.NewClosedCircuitRelayFilter(cfg.Peers),
-		p2p.NewRecursionGater(cfg),
+		p2p.NewMultiGater(
+			p2p.NewRecursionGater(cfg),
+			p2p.NewAutoFilterGater(),
+		),
 		cfg.Peers,
 	)
 	checkErr(err)

--- a/p2p/autofilter.go
+++ b/p2p/autofilter.go
@@ -1,0 +1,47 @@
+package p2p
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// a FilterGater that automatically filters all addresses present in the current unit's IPAddressDeny list
+func NewAutoFilterGater() connmgr.ConnectionGater {
+	fg := NewFilterGater()
+
+	conn, err := dbus.NewSystemConnectionContext(context.Background())
+	if err != nil {
+		return fg
+	}
+	unit, err := conn.GetUnitNameByPID(context.Background(), uint32(os.Getpid()))
+	if err != nil {
+		return fg
+	}
+	prop, err := conn.GetServicePropertyContext(context.Background(), unit, "IPAddressDeny")
+	if err != nil {
+		return fg
+	}
+	for _, v := range prop.Value.Value().([][]interface{}) {
+		addr := net.IP(v[1].([]byte))
+		cidr := v[2].(uint32)
+		var mask net.IPMask
+		switch v[0].(int32) {
+		case 0x2:
+			mask = net.CIDRMask(int(cidr), 32)
+		case 0xa:
+			mask = net.CIDRMask(int(cidr), 128)
+		default:
+			panic("unknown IP address type")
+		}
+		fg.(FilterGater).Filters.AddFilter(net.IPNet{
+			IP:   addr,
+			Mask: mask,
+		}, multiaddr.ActionDeny)
+	}
+	return fg
+}

--- a/p2p/filter.go
+++ b/p2p/filter.go
@@ -1,0 +1,39 @@
+package p2p
+
+import (
+	"github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/libp2p/go-libp2p/core/control"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type FilterGater struct {
+	Filters *multiaddr.Filters
+}
+
+func NewFilterGater() connmgr.ConnectionGater {
+	return FilterGater{
+		Filters: multiaddr.NewFilters(),
+	}
+}
+
+func (f FilterGater) InterceptAccept(addrs network.ConnMultiaddrs) (allow bool) {
+	return !f.Filters.AddrBlocked(addrs.RemoteMultiaddr())
+}
+
+func (f FilterGater) InterceptAddrDial(_ peer.ID, addr multiaddr.Multiaddr) (allow bool) {
+	return !f.Filters.AddrBlocked(addr)
+}
+
+func (f FilterGater) InterceptPeerDial(peer.ID) (allow bool) {
+	return true
+}
+
+func (f FilterGater) InterceptSecured(_ network.Direction, _ peer.ID, addrs network.ConnMultiaddrs) (allow bool) {
+	return !f.Filters.AddrBlocked(addrs.RemoteMultiaddr())
+}
+
+func (f FilterGater) InterceptUpgraded(network.Conn) (allow bool, reason control.DisconnectReason) {
+	return true, 0
+}

--- a/p2p/multigater.go
+++ b/p2p/multigater.go
@@ -1,0 +1,65 @@
+package p2p
+
+import (
+	"github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/libp2p/go-libp2p/core/control"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	multiaddr "github.com/multiformats/go-multiaddr"
+)
+
+// MultiGater combines a list of ConnectionGaters. All gaters must return true to allow the connection.
+type MultiGater struct {
+	gaters []connmgr.ConnectionGater
+}
+
+func NewMultiGater(gaters ...connmgr.ConnectionGater) connmgr.ConnectionGater {
+	return MultiGater{
+		gaters: gaters,
+	}
+}
+
+func (m MultiGater) InterceptAccept(addrs network.ConnMultiaddrs) (allow bool) {
+	for _, g := range m.gaters {
+		if !g.InterceptAccept(addrs) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m MultiGater) InterceptAddrDial(p peer.ID, addr multiaddr.Multiaddr) (allow bool) {
+	for _, g := range m.gaters {
+		if !g.InterceptAddrDial(p, addr) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m MultiGater) InterceptPeerDial(p peer.ID) (allow bool) {
+	for _, g := range m.gaters {
+		if !g.InterceptPeerDial(p) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m MultiGater) InterceptSecured(d network.Direction, p peer.ID, addrs network.ConnMultiaddrs) (allow bool) {
+	for _, g := range m.gaters {
+		if !g.InterceptSecured(d, p, addrs) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m MultiGater) InterceptUpgraded(conn network.Conn) (allow bool, reason control.DisconnectReason) {
+	for _, g := range m.gaters {
+		if ok, reason := g.InterceptUpgraded(conn); !ok {
+			return false, reason
+		}
+	}
+	return true, 0
+}

--- a/p2p/routing.go
+++ b/p2p/routing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hyprspace/hyprspace/config"
+	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/control"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -52,7 +53,7 @@ type RecursionGater struct {
 	ifindex int
 }
 
-func NewRecursionGater(config *config.Config) RecursionGater {
+func NewRecursionGater(config *config.Config) connmgr.ConnectionGater {
 	link, err := netlink.LinkByName(config.Interface)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This will look up the current unit's `IPAddressDeny` list and configure a ConnectionGater to prevent libp2p from trying to connect to those addresses in the first place, which should prevent a bunch of pointless dials.

**TODO**: Also look at `IPAddressAllow`

I *think* this is the reason why I'm getting so many "other" dial failures when running Hyprspace in an environment with a strict IPAddressDeny list.

![image](https://github.com/privatevoid-net/hyprspace/assets/55053574/1d0c12c1-c4fb-471e-bc3a-d9a5428da8fc)
