### PR TITLE
nix: unshittify

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,23 +9,32 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, ... }:
+  outputs =
+    inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-      flake.herculesCI.ciSystems = [ "x86_64-linux" "aarch64-linux" ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      flake.herculesCI.ciSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
 
-      perSystem = { pkgs, ... }: {
-        packages.default = pkgs.callPackage ./package.nix {};
+      perSystem =
+        { pkgs, ... }:
+        {
+          packages.default = pkgs.callPackage ./package.nix { };
 
-        devShells.default = pkgs.mkShell {
-          packages = [
-            pkgs.go
-          ];
+          devShells.default = pkgs.mkShell {
+            packages = [ pkgs.go ];
 
-          shellHook = ''
-            export GOPATH="$PWD/.data/go";
-          '';
+            shellHook = ''
+              export GOPATH="$PWD/.data/go";
+            '';
+          };
         };
-      };
     };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,20 +1,18 @@
 { lib, buildGoModule }:
-
 let
-  fs = lib.fileset;
-in
-
-buildGoModule rec {
+  inherit (lib.fileset) toSource unions fileFilter;
   pname = "hyprspace";
   version = "0.9.0";
-
-  src = fs.toSource {
+in
+buildGoModule {
+  inherit pname version;
+  src = toSource {
     root = ./.;
-    fileset = fs.unions [
+    fileset = unions [
       ./go.mod
       ./go.sum
 
-      (fs.fileFilter (file: file.hasExt "go") ./.)
+      (fileFilter (file: file.hasExt "go") ./.)
     ];
   };
 
@@ -22,14 +20,20 @@ buildGoModule rec {
 
   vendorHash = "sha256-LJpgGeD47Bs+Cq9Z7WWFa49F8/n3exOyxRcd6EkkL2g=";
 
-  ldflags = [ "-s" "-w" "-X github.com/hyprspace/hyprspace/cli.appVersion=${version}" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/hyprspace/hyprspace/cli.appVersion=${version}"
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "A Lightweight VPN Built on top of Libp2p for Truly Distributed Networks.";
     homepage = "https://github.com/hyprspace/hyprspace";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ yusdacra ];
-    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.asl20;
+    maintainers = with lib; [
+      notashelf
+      yusdacra
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }
-


### PR DESCRIPTION
- Removes the discouraged, and frankly unintelligible `rec` usage.
- Gets rid of `with lib; to explicitly call library functions in meta.
- Replaces fs alias with inherits of lib.fileset` functions
- Formats via alejandra