### PR TITLE
Reserve 2 relay address slots for unlimited relays

### DIFF
--- a/p2p/node.go
+++ b/p2p/node.go
@@ -291,7 +291,18 @@ func CreateNode(ctx context.Context, privateKey crypto.PrivKey, listenAddreses [
 		for {
 			for _, p := range node.Network().Peers() {
 				pi := node.Network().Peerstore().PeerInfo(p)
-				peerChan <- pi
+				relayCount := 0
+				for _, la := range node.Network().ListenAddresses() {
+					for _, proto := range la.Protocols() {
+						if proto.Code == ma.P_CIRCUIT {
+							relayCount = relayCount + 1
+							break
+						}
+					}
+				}
+				if relayCount < 2 || acl.AllowReserve(p, node.Addrs()[0]) {
+					peerChan <- pi
+				}
 			}
 			time.Sleep(delay.Delay())
 		}


### PR DESCRIPTION
After running #29 for a bit, it seems like nodes are way too likely to register themselves on limited relays, which results in them not being reachable over a relay in situations where connectivity is heavily limited. To counter this, increase the target number of relays to 4, and ensure that at least 2 of those are our own unlimited relays.

2 known bugs:
- [ ] The method used to count relays in the goroutine feeding the peer channel is incorrect: it counts /p2p-circuit addresses instead of actual relay registrations.
- [ ] The method to determine which relays are ours is technically inaccurate: it considers the peers that the current node trusts, as opposed to peers that trust our node (same as in the original "only use unlimited relays" situation). In practice, having non-mutual trust is probably unlikely anyway.