### PR TITLE
Implementation for basic service access control

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,8 +54,8 @@ type RouteTableEntry struct {
 // If Blacklist is set, this will be evaluated first and any client id present in Blacklist will
 // have access denied. Whitelist is evaluated after.
 type ServiceACL struct {
-	Whitelist []string
-	Blacklist []string
+	Whitelist map[peer.ID]interface{}
+	Blacklist map[peer.ID]interface{}
 }
 
 func (rte RouteTableEntry) Network() net.IPNet {
@@ -170,6 +170,7 @@ func Read(path string) (*Config, error) {
 func FindPeer(peers []Peer, needle peer.ID) (*Peer, bool) {
 	for _, p := range peers {
 		if p.ID == needle {
+
 			return &p, true
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	BuiltinAddr4    net.IP                         `json:"-"`
 	BuiltinAddr6    net.IP                         `json:"-"`
 	Services        map[string]multiaddr.Multiaddr `json:"-"`
+	ServicesACL     map[string]ServiceACL          `json:"-"`
 }
 
 // Peer defines a peer in the configuration. We might add more to this later.
@@ -47,6 +48,14 @@ type PeerLookup struct {
 type RouteTableEntry struct {
 	Net    net.IPNet
 	Target Peer
+}
+
+// ServiceACL allows to specify fine granularity in access control to a specific service.
+// If Blacklist is set, this will be evaluated first and any client id present in Blacklist will
+// have access denied. Whitelist is evaluated after.
+type ServiceACL struct {
+	Whitelist []string
+	Blacklist []string
 }
 
 func (rte RouteTableEntry) Network() net.IPNet {

--- a/config/config.go
+++ b/config/config.go
@@ -194,7 +194,6 @@ func Read(path string) (*Config, error) {
 func FindPeer(peers []Peer, needle peer.ID) (*Peer, bool) {
 	for _, p := range peers {
 		if p.ID == needle {
-
 			return &p, true
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	BuiltinAddr4    net.IP                         `json:"-"`
 	BuiltinAddr6    net.IP                         `json:"-"`
 	Services        map[string]multiaddr.Multiaddr `json:"-"`
-	ServicesACL     map[string]ServiceACL          `json:"-"`
+	ServicesACL     map[string]ServiceACLList      `json:"-"`
 }
 
 // Peer defines a peer in the configuration. We might add more to this later.
@@ -56,6 +56,11 @@ type RouteTableEntry struct {
 type ServiceACL struct {
 	Whitelist map[peer.ID]interface{}
 	Blacklist map[peer.ID]interface{}
+}
+
+type ServiceACLList struct {
+	Whitelist []peer.ID
+	Blacklist []peer.ID
 }
 
 func (rte RouteTableEntry) Network() net.IPNet {

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	BuiltinAddr4    net.IP                         `json:"-"`
 	BuiltinAddr6    net.IP                         `json:"-"`
 	Services        map[string]multiaddr.Multiaddr `json:"-"`
-	ServicesACL     map[string]ServiceACLList      `json:"-"`
+	ServicesACL     map[string]ServiceACLList      `json:"acls"`
 }
 
 // Peer defines a peer in the configuration. We might add more to this later.
@@ -59,8 +59,8 @@ type ServiceACL struct {
 }
 
 type ServiceACLList struct {
-	Whitelist []peer.ID
-	Blacklist []peer.ID
+	Whitelist []peer.ID `json:"whitelist"`
+	Blacklist []peer.ID `json:"blacklist"`
 }
 
 func (rte RouteTableEntry) Network() net.IPNet {
@@ -165,6 +165,31 @@ func Read(path string) (*Config, error) {
 			return nil, err
 		}
 		result.Services[name] = addr
+	}
+
+	result.ServicesACL = make(map[string]ServiceACLList)
+	for service, acls := range input.Acls {
+		whitelist := make([]peer.ID, len(acls.Whitelist))
+		blacklist := make([]peer.ID, len(acls.Blacklist))
+		for i, peerIDString := range acls.Whitelist {
+			peerID, err := peer.Decode(peerIDString)
+			if err != nil {
+				return nil, err
+			}
+			whitelist[i] = peerID
+		}
+
+		for i, peerIDString := range acls.Blacklist {
+			peerID, err := peer.Decode(peerIDString)
+			if err != nil {
+				return nil, err
+			}
+			blacklist[i] = peerID
+		}
+		result.ServicesACL[service] = ServiceACLList{
+			Whitelist: whitelist,
+			Blacklist: blacklist,
+		}
 	}
 
 	// Overwrite path of config to input.

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -18,16 +19,15 @@ import (
 
 // Config is the main Configuration Struct for Hyprspace.
 type Config struct {
-	Path            string                         `json:"-"`
-	Interface       string                         `json:"-"`
-	ListenAddresses []multiaddr.Multiaddr          `json:"-"`
-	Peers           []Peer                         `json:"peers"`
-	PeerLookup      PeerLookup                     `json:"-"`
-	PrivateKey      crypto.PrivKey                 `json:"-"`
-	BuiltinAddr4    net.IP                         `json:"-"`
-	BuiltinAddr6    net.IP                         `json:"-"`
-	Services        map[string]multiaddr.Multiaddr `json:"-"`
-	ServicesACL     map[string]ServiceACLList      `json:"acls"`
+	Path            string                `json:"-"`
+	Interface       string                `json:"-"`
+	ListenAddresses []multiaddr.Multiaddr `json:"-"`
+	Peers           []Peer                `json:"peers"`
+	PeerLookup      PeerLookup            `json:"-"`
+	PrivateKey      crypto.PrivKey        `json:"-"`
+	BuiltinAddr4    net.IP                `json:"-"`
+	BuiltinAddr6    net.IP                `json:"-"`
+	Services        map[string]Service    `json:"-"`
 }
 
 // Peer defines a peer in the configuration. We might add more to this later.
@@ -50,17 +50,15 @@ type RouteTableEntry struct {
 	Target Peer
 }
 
-// ServiceACL allows to specify fine granularity in access control to a specific service.
+// Service represents the configuration for a specific service provided by this node.
+// Whitelist and Blacklist allow fine granularity in access control.
 // If Blacklist is set, this will be evaluated first and any client id present in Blacklist will
 // have access denied. Whitelist is evaluated after.
-type ServiceACL struct {
-	Whitelist map[peer.ID]interface{}
-	Blacklist map[peer.ID]interface{}
-}
-
-type ServiceACLList struct {
-	Whitelist []peer.ID `json:"whitelist"`
-	Blacklist []peer.ID `json:"blacklist"`
+type Service struct {
+	Target          multiaddr.Multiaddr
+	EnableWhitelist bool
+	Whitelist       map[peer.ID]struct{}
+	Blacklist       map[peer.ID]struct{}
 }
 
 func (rte RouteTableEntry) Network() net.IPNet {
@@ -158,37 +156,33 @@ func Read(path string) (*Config, error) {
 		result.Peers[i] = p
 	}
 
-	result.Services = make(map[string]multiaddr.Multiaddr)
-	for name, addrString := range input.Services {
-		addr, err := multiaddr.NewMultiaddr(addrString)
+	result.Services = make(map[string]Service)
+	for name, service := range input.Services {
+		addr, err := multiaddr.NewMultiaddr(service.Target)
 		if err != nil {
 			return nil, err
 		}
-		result.Services[name] = addr
-	}
-
-	result.ServicesACL = make(map[string]ServiceACLList)
-	for service, acls := range input.Acls {
-		whitelist := make([]peer.ID, len(acls.Whitelist))
-		blacklist := make([]peer.ID, len(acls.Blacklist))
-		for i, peerIDString := range acls.Whitelist {
-			peerID, err := peer.Decode(peerIDString)
-			if err != nil {
-				return nil, err
+		whitelist := make(map[peer.ID]struct{})
+		blacklist := make(map[peer.ID]struct{})
+		for _, p := range service.Acl.Whitelist {
+			cfgPeer, found := FindPeerByCLIRef(result.Peers, p)
+			if !found {
+				return nil, errors.New("unknown peer: " + p)
 			}
-			whitelist[i] = peerID
+			whitelist[cfgPeer.ID] = struct{}{}
 		}
-
-		for i, peerIDString := range acls.Blacklist {
-			peerID, err := peer.Decode(peerIDString)
-			if err != nil {
-				return nil, err
+		for _, peerStr := range service.Acl.Blacklist {
+			cfgPeer, found := FindPeerByCLIRef(result.Peers, peerStr)
+			if !found {
+				return nil, errors.New("unknown peer: " + peerStr)
 			}
-			blacklist[i] = peerID
+			blacklist[cfgPeer.ID] = struct{}{}
 		}
-		result.ServicesACL[service] = ServiceACLList{
-			Whitelist: whitelist,
-			Blacklist: blacklist,
+		result.Services[name] = Service{
+			Target:          addr,
+			EnableWhitelist: service.Acl.EnableWhitelist,
+			Whitelist:       whitelist,
+			Blacklist:       blacklist,
 		}
 	}
 

--- a/dev/pkgs/go-jsonschema/default.nix
+++ b/dev/pkgs/go-jsonschema/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     rev = "v${version}";
     hash = "sha256-ffrP4L5cfK75Tw/xfcdXAwGUP8WLL+81ltBDb/P5Gwo=";
   };
-  
+
   env.GOWORK = "off";
 
   vendorHash = "sha256-mCOJ8GROrbNXH7CSLLMZj/4wTa65hscTt8RzIxzgG+A=";

--- a/dev/pkgs/go-jsonschema/default.nix
+++ b/dev/pkgs/go-jsonschema/default.nix
@@ -6,16 +6,18 @@
 
 buildGoModule rec {
   pname = "go-jsonschema";
-  version = "0.16.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "omissis";
     repo = "go-jsonschema";
     rev = "v${version}";
-    hash = "sha256-+CapTmg4RObK6mzjAS/EFbX4s2AtQvlFXmT119aUkZA=";
+    hash = "sha256-ffrP4L5cfK75Tw/xfcdXAwGUP8WLL+81ltBDb/P5Gwo=";
   };
+  
+  env.GOWORK = "off";
 
-  vendorHash = "sha256-gk+aKGqcHEjuYxc2o+83HA2AxU+jT7URt0N/q+uyUtA=";
+  vendorHash = "sha256-mCOJ8GROrbNXH7CSLLMZj/4wTa65hscTt8RzIxzgG+A=";
 
   ldflags = [
     "-s"

--- a/nixos/settings.nix
+++ b/nixos/settings.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
 
-  inherit (lib) types mkOption;
+  inherit (lib) types mkOption mkEnableOption;
 
   t = {
     multiAddr = types.strMatching "/.*[^/]" // {
@@ -39,6 +39,40 @@ let
           description = "Networks to route to this peer. (optional)";
           default = [ ];
           example = [ { net = "10.10.0.0/16"; } ];
+        };
+      };
+    };
+
+    service = types.submodule {
+      options = {
+        target = mkOption {
+          type = t.multiAddr;
+          description = "Target address.";
+          example = "/tcp/8080";
+        };
+
+        acl = {
+          enableWhitelist = mkEnableOption "whitelist enforcement";
+
+          whitelist = mkOption {
+            type = types.listOf types.str;
+            description = "List of peers that are allowed to connect.";
+            example = [
+              "12D3KooWQWiPeNvXFdHFTrustedPeer"
+              "@goodpeer"
+            ];
+            default = null;
+          };
+
+          blacklist = mkOption {
+            type = types.listOf types.str;
+            description = "List of peers that are explicitly not allowed to connect.";
+            example = [
+              "12D3KooWQWiPeNvXFdHFUntrustedPeer"
+              "@badpeer"
+            ];
+            default = null;
+          };
         };
       };
     };
@@ -82,28 +116,24 @@ in
     };
 
     services = mkOption {
-      type = types.attrsOf t.multiAddr;
+      type = types.attrsOf t.service;
       description = "The services this node provides via the Service Network.";
       default = { };
       example = {
-        "www-local" = "/tcp/8080";
-        "gameserver" = "/ip4/10.0.0.2/tcp/27015";
-      };
-    };
-
-    acls = mkOption {
-      type = types.attrsOf (
-        types.submodule {
-          options = {
-            whitelist = mkOption {
-              type = types.listOf types.str;
-            };
-            blacklist = mkOption {
-              type = types.listOf types.str;
-            };
+        www-local = {
+          target = "/tcp/8080";
+        };
+        gameserver = {
+          target = "/ip4/10.0.0.2/tcp/27015";
+          acl = {
+            enableWhitelist = true;
+            whitelist = [
+              "@friend1"
+              "@friend2"
+            ];
           };
-        }
-      );
+        };
+      };
     };
   };
 }

--- a/nixos/settings.nix
+++ b/nixos/settings.nix
@@ -90,5 +90,20 @@ in
         "gameserver" = "/ip4/10.0.0.2/tcp/27015";
       };
     };
+
+    acls = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            whitelist = mkOption {
+              type = types.listOf types.str;
+            };
+            blacklist = mkOption {
+              type = types.listOf types.str;
+            };
+          };
+        }
+      );
+    };
   };
 }

--- a/node/node.go
+++ b/node/node.go
@@ -180,8 +180,8 @@ func (node *Node) Run() error {
 
 	serviceNet := svc.NewServiceNetwork(node.p2p, node.cfg, node.tunDev)
 
-	for name, addr := range node.cfg.Services {
-		proxy, err := svc.ProxyTo(addr)
+	for name, service := range node.cfg.Services {
+		proxy, err := svc.ProxyTo(service.Target)
 		if err != nil {
 			return err
 		}

--- a/svc/network.go
+++ b/svc/network.go
@@ -30,11 +30,13 @@ type ServiceNetwork struct {
 	activeAddrs  map[[16]byte]struct{}
 	activePorts  map[[16]byte]map[uint16]struct{}
 	listeners    map[[2]byte]Proxy
+	acl          map[[2]byte]config.ServiceACL
 }
 
 func (sn *ServiceNetwork) Register(serviceName string, proxy Proxy) {
 	svcId := config.MkServiceID(serviceName)
 	sn.listeners[svcId] = proxy
+	sn.acl[svcId] = sn.config.ServicesACL[serviceName]
 	logger.With(zap.String("name", serviceName), zap.ByteString("id", svcId[:]), zap.String("description", proxy.Description)).Debug("Registered service")
 }
 

--- a/svc/network.go
+++ b/svc/network.go
@@ -39,14 +39,16 @@ func parseACL(configACL config.ServiceACLList) config.ServiceACL {
 	if configACL.Blacklist != nil {
 		acl.Blacklist = make(map[peer.ID]interface{})
 		for _, blackListedPeer := range configACL.Blacklist {
-			acl.Blacklist[blackListedPeer] = nil
+			acl.Blacklist[blackListedPeer] = struct{}{}
 		}
+		logger.Debug("Blacklist configured")
 	}
 	if configACL.Whitelist != nil {
 		acl.Whitelist = make(map[peer.ID]interface{})
 		for _, whitelistedPeer := range configACL.Whitelist {
-			acl.Whitelist[whitelistedPeer] = nil
+			acl.Whitelist[whitelistedPeer] = struct{}{}
 		}
+		logger.Debug("Whitelist configured")
 	}
 	return acl
 }
@@ -55,7 +57,7 @@ func (sn *ServiceNetwork) Register(serviceName string, proxy Proxy) {
 	svcId := config.MkServiceID(serviceName)
 	sn.listeners[svcId] = proxy
 	sn.acl[svcId] = parseACL(sn.config.ServicesACL[serviceName])
-	logger.With(zap.String("name", serviceName), zap.ByteString("id", svcId[:]), zap.String("description", proxy.Description)).Debug("Registered service")
+	logger.With(zap.String("name", serviceName), zap.String("id", fmt.Sprintf("%x", svcId[:])), zap.String("description", proxy.Description)).Info("Registered service")
 }
 
 func (sn *ServiceNetwork) EnsureListener(addr [16]byte, port uint16) bool {
@@ -151,6 +153,7 @@ func NewServiceNetwork(host host.Host, cfg *config.Config, tunDev *hstun.TUN) Se
 		activeAddrs: make(map[[16]byte]struct{}),
 		activePorts: make(map[[16]byte]map[uint16]struct{}),
 		listeners:   make(map[[2]byte]Proxy),
+		acl:         make(map[[2]byte]config.ServiceACL),
 	}
 
 	host.SetStreamHandler(Protocol, sn.streamHandler())

--- a/svc/network.go
+++ b/svc/network.go
@@ -10,7 +10,6 @@ import (
 	hstun "github.com/hyprspace/hyprspace/tun"
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 	"golang.zx2c4.com/wireguard/tun"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -31,32 +30,13 @@ type ServiceNetwork struct {
 	activeAddrs  map[[16]byte]struct{}
 	activePorts  map[[16]byte]map[uint16]struct{}
 	listeners    map[[2]byte]Proxy
-	acl          map[[2]byte]config.ServiceACL
-}
-
-func parseACL(configACL config.ServiceACLList) config.ServiceACL {
-	acl := config.ServiceACL{}
-	if configACL.Blacklist != nil {
-		acl.Blacklist = make(map[peer.ID]interface{})
-		for _, blackListedPeer := range configACL.Blacklist {
-			acl.Blacklist[blackListedPeer] = struct{}{}
-		}
-		logger.Debug("Blacklist configured")
-	}
-	if configACL.Whitelist != nil {
-		acl.Whitelist = make(map[peer.ID]interface{})
-		for _, whitelistedPeer := range configACL.Whitelist {
-			acl.Whitelist[whitelistedPeer] = struct{}{}
-		}
-		logger.Debug("Whitelist configured")
-	}
-	return acl
+	services     map[[2]byte]config.Service
 }
 
 func (sn *ServiceNetwork) Register(serviceName string, proxy Proxy) {
 	svcId := config.MkServiceID(serviceName)
 	sn.listeners[svcId] = proxy
-	sn.acl[svcId] = parseACL(sn.config.ServicesACL[serviceName])
+	sn.services[svcId] = sn.config.Services[serviceName]
 	logger.With(zap.String("name", serviceName), zap.String("id", fmt.Sprintf("%x", svcId[:])), zap.String("description", proxy.Description)).Info("Registered service")
 }
 
@@ -153,7 +133,7 @@ func NewServiceNetwork(host host.Host, cfg *config.Config, tunDev *hstun.TUN) Se
 		activeAddrs: make(map[[16]byte]struct{}),
 		activePorts: make(map[[16]byte]map[uint16]struct{}),
 		listeners:   make(map[[2]byte]Proxy),
-		acl:         make(map[[2]byte]config.ServiceACL),
+		services:    make(map[[2]byte]config.Service),
 	}
 
 	host.SetStreamHandler(Protocol, sn.streamHandler())

--- a/svc/network.go
+++ b/svc/network.go
@@ -10,6 +10,7 @@ import (
 	hstun "github.com/hyprspace/hyprspace/tun"
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 	"golang.zx2c4.com/wireguard/tun"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -33,10 +34,27 @@ type ServiceNetwork struct {
 	acl          map[[2]byte]config.ServiceACL
 }
 
+func parseACL(configACL config.ServiceACLList) config.ServiceACL {
+	acl := config.ServiceACL{}
+	if configACL.Blacklist != nil {
+		acl.Blacklist = make(map[peer.ID]interface{})
+		for _, blackListedPeer := range configACL.Blacklist {
+			acl.Blacklist[blackListedPeer] = nil
+		}
+	}
+	if configACL.Whitelist != nil {
+		acl.Whitelist = make(map[peer.ID]interface{})
+		for _, whitelistedPeer := range configACL.Whitelist {
+			acl.Whitelist[whitelistedPeer] = nil
+		}
+	}
+	return acl
+}
+
 func (sn *ServiceNetwork) Register(serviceName string, proxy Proxy) {
 	svcId := config.MkServiceID(serviceName)
 	sn.listeners[svcId] = proxy
-	sn.acl[svcId] = sn.config.ServicesACL[serviceName]
+	sn.acl[svcId] = parseACL(sn.config.ServicesACL[serviceName])
 	logger.With(zap.String("name", serviceName), zap.ByteString("id", svcId[:]), zap.String("description", proxy.Description)).Debug("Registered service")
 }
 

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -69,8 +69,9 @@ func ProxyTo(ma multiaddr.Multiaddr) (Proxy, error) {
 type RemoteServiceProxyStatus byte
 
 const (
-	RS_OK            RemoteServiceProxyStatus = 0xf1
-	RS_NOT_SUPPORTED RemoteServiceProxyStatus = 0xf2
+	RS_OK             RemoteServiceProxyStatus = 0xf1
+	RS_NOT_SUPPORTED  RemoteServiceProxyStatus = 0xf2
+	RS_NOT_AUTHORIZED RemoteServiceProxyStatus = 0xf3
 )
 
 func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) Proxy {

--- a/svc/proxy.go
+++ b/svc/proxy.go
@@ -96,7 +96,7 @@ func RemoteServiceProxy(host host.Host, p peer.ID, svcId [2]byte) Proxy {
 				logger.With(err).Error("Failed to read from stream")
 				return
 			} else if buf[0] != byte(RS_OK) {
-				logger.With(zap.String("peer", p.String()), zap.ByteString("service", svcId[:])).Warn("Peer does not support service")
+				logger.With(zap.String("peer", p.String()), zap.String("service", fmt.Sprintf("%x", svcId[:]))).Warn("Peer does not support service")
 				return
 			}
 			pipe(conn, stream)

--- a/svc/receiver.go
+++ b/svc/receiver.go
@@ -5,8 +5,27 @@ import (
 
 	"github.com/hyprspace/hyprspace/config"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 )
+
+func (sn *ServiceNetwork) isRemoteBlocked(svcId [2]byte, remotePeer peer.ID) bool {
+	if _, ok := sn.acl[svcId]; ok {
+		isBlacklisted := false // without blacklist it's NOT-blacklisted by default
+		isWhitelisted := true  // without whitelist it IS whitelisted by default
+		if sn.acl[svcId].Blacklist != nil {
+			_, isBlacklisted = sn.acl[svcId].Blacklist[remotePeer]
+			if isBlacklisted {
+				return true
+			}
+		}
+		if sn.acl[svcId].Whitelist != nil {
+			_, isWhitelisted = sn.acl[svcId].Whitelist[remotePeer]
+		}
+		return isBlacklisted || !isWhitelisted
+	}
+	return false
+}
 
 func (sn *ServiceNetwork) streamHandler() func(network.Stream) {
 	return func(stream network.Stream) {
@@ -25,22 +44,16 @@ func (sn *ServiceNetwork) streamHandler() func(network.Stream) {
 		svcId := [2]byte(buf)
 		if proxy, ok := sn.listeners[svcId]; ok {
 			remotePeer := stream.Conn().RemotePeer()
-			if _, ok := sn.acl[svcId]; ok {
-				if sn.acl[svcId].Blacklist != nil {
-					if _, isBlacklisted := sn.acl[svcId].Blacklist[remotePeer]; isBlacklisted {
-						logger.With(zap.ByteString("service ID", svcId[:])).Warn("Connection from blacklisted peer")
-						stream.Reset()
-						return
-					}
+			if sn.isRemoteBlocked(svcId, remotePeer) {
+				logger.With(zap.ByteString("service ID", svcId[:])).Warn("Connection from non-allowed peer")
+				_, err := stream.Write([]byte{byte(RS_NOT_AUTHORIZED)})
+				if err != nil {
+					logger.With(err).Error("Failed to send RS_NOT_AUTHORIZED")
+					return
 				}
+				return
 			}
-			// TODO check whitelist
-			//
-			//
-			//
-			//
-			//
-			//
+
 			_, err := stream.Write([]byte{byte(RS_OK)})
 			if err != nil {
 				logger.With(err).Error("Failed to write stream")

--- a/svc/receiver.go
+++ b/svc/receiver.go
@@ -45,7 +45,7 @@ func (sn *ServiceNetwork) streamHandler() func(network.Stream) {
 		if proxy, ok := sn.listeners[svcId]; ok {
 			remotePeer := stream.Conn().RemotePeer()
 			if sn.isRemoteBlocked(svcId, remotePeer) {
-				logger.With(zap.ByteString("service ID", svcId[:])).Warn("Connection from non-allowed peer")
+				logger.With(zap.String("service ID", fmt.Sprintf("%x", svcId[:]))).Debug("Connection from non-allowed peer")
 				_, err := stream.Write([]byte{byte(RS_NOT_AUTHORIZED)})
 				if err != nil {
 					logger.With(err).Error("Failed to send RS_NOT_AUTHORIZED")

--- a/svc/receiver.go
+++ b/svc/receiver.go
@@ -10,21 +10,10 @@ import (
 )
 
 func (sn *ServiceNetwork) isRemoteBlocked(svcId [2]byte, remotePeer peer.ID) bool {
-	if _, ok := sn.acl[svcId]; ok {
-		isBlacklisted := false // without blacklist it's NOT-blacklisted by default
-		isWhitelisted := true  // without whitelist it IS whitelisted by default
-		if sn.acl[svcId].Blacklist != nil {
-			_, isBlacklisted = sn.acl[svcId].Blacklist[remotePeer]
-			if isBlacklisted {
-				return true
-			}
-		}
-		if sn.acl[svcId].Whitelist != nil {
-			_, isWhitelisted = sn.acl[svcId].Whitelist[remotePeer]
-		}
-		return isBlacklisted || !isWhitelisted
-	}
-	return false
+	sv := sn.services[svcId]
+	_, isWhitelisted := sv.Whitelist[remotePeer]
+	_, isBlacklisted := sv.Blacklist[remotePeer]
+	return isBlacklisted || (sv.EnableWhitelist && !isWhitelisted)
 }
 
 func (sn *ServiceNetwork) streamHandler() func(network.Stream) {


### PR DESCRIPTION
This MR fixes #78 
A simple configuration option to allow whitelisting and blacklisting of peers per service has been implemented.