### PR TITLE
Add init name flag

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -13,11 +13,17 @@ import (
 	"github.com/multiformats/go-multibase"
 )
 
+// InitFlags Contains flags for the init command.
+type InitFlags struct {
+	Name string `long:"name" desc:"Name to include in the suggested peer entry."`
+}
+
 // Init creates a configuration for a Hyprspace Interface.
 var Init = cmd.Sub{
 	Name:  "init",
 	Alias: "i",
 	Short: "Initialize An Interface Config",
+	Flags: &InitFlags{},
 	Run:   InitRun,
 }
 
@@ -70,9 +76,15 @@ func InitRun(r *cmd.Root, c *cmd.Sub) {
 	if err == nil {
 		fmt.Println("Add this entry to your other peers:")
 		fmt.Println("{")
-		hostname, err := os.Hostname()
-		if err == nil {
-			fmt.Printf("  \"name\": \"%s\",\n", hostname)
+		name := c.Flags.(*InitFlags).Name
+		if name == "" {
+			hostname, err := os.Hostname()
+			if err == nil {
+				name = hostname
+			}
+		}
+		if name != "" {
+			fmt.Printf("  \"name\": \"%s\",\n", name)
 		}
 		fmt.Printf("  \"id\": \"%s\"\n", peerId)
 		fmt.Println("}")


### PR DESCRIPTION
## Fixes #106 

Adds an optional `--name` flag to `hyprspace init`.

When provided, the value is used as the `name` in the suggested peer entry printed after config generation. When omitted, `init` keeps the existing behavior of falling back to the system hostname.

This is useful for scripts that bulk-generate configs/keys for multiple nodes from one machine.

  ## Tested using:

  - `gofmt -w cli/init.go`
  - `go run . init -c /dev/null --name test-node`
  - `go run . init -c /dev/null`