### PR TITLE
Add tesh integration tests for deterministic CLI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ result-*
 .data/
 *_generated.go
 .direnv/
+
+# tesh shell history
+tesh/.bash_history
+tests/tesh/.bash_history

--- a/tests/tesh/help.md
+++ b/tests/tesh/help.md
@@ -1,0 +1,137 @@
+# tesh: Testable CLI help examples for hyprspace
+
+These tests verify that the CLI help output remains consistent.
+
+## Main help
+
+```console tesh-session="main-help" tesh-exitcodes="1"
+$ hyprspace --help
+USAGE: hyprspace CMD [OPTIONS]
+...
+DESCRIPTION: Hyprspace Distributed Network
+...
+COMMANDS:
+...
+    NAME     ALIAS  DESCRIPTION
+    help     ?      Get help with a specific subcommand
+    init     i      Initialize An Interface Config
+    peers           List peer connections
+    route    r      Control routing
+    status   s      Display Hyprspace daemon status
+    up       up     Create and Bring Up a Hyprspace Interface.
+    version         Print the version of this command
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```
+
+## Help without subcommand (error)
+
+```console tesh-session="help-no-arg" tesh-exitcodes="1"
+$ hyprspace help
+Error: Missing argument(s)
+...
+USAGE: hyprspace help [OPTIONS] <Subcommand>
+...
+DESCRIPTION: Get help with a specific subcommand
+...
+ARGUMENTS:
+...
+    NAME        TYPE    DESCRIPTION
+    Subcommand  STRING  Command to get help for
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```
+
+## Init help
+
+```console tesh-session="init-help"
+$ hyprspace help init
+USAGE: hyprspace init [OPTIONS]
+...
+DESCRIPTION: Initialize An Interface Config
+...
+INIT FLAGS:
+...
+    NAME    ARG     DESCRIPTION
+    --name  STRING  Name to include in the suggested peer entry.
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```
+
+## Up help
+
+```console tesh-session="up-help"
+$ hyprspace help up
+USAGE: hyprspace up [OPTIONS]
+...
+DESCRIPTION: Create and Bring Up a Hyprspace Interface.
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```
+
+## Status help
+
+```console tesh-session="status-help"
+$ hyprspace help status
+USAGE: hyprspace status [OPTIONS]
+...
+DESCRIPTION: Display Hyprspace daemon status
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```
+
+## Peers help
+
+```console tesh-session="peers-help"
+$ hyprspace help peers
+USAGE: hyprspace peers [OPTIONS]
+...
+DESCRIPTION: List peer connections
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```
+
+## Route help
+
+```console tesh-session="route-help"
+$ hyprspace help route
+USAGE: hyprspace route [OPTIONS] <Action> [Args...]
+...
+DESCRIPTION: Control routing
+...
+ARGUMENTS:
+...
+    NAME    TYPE      DESCRIPTION
+    Action  STRING
+    Args    []STRING
+...
+GLOBAL FLAGS:
+...
+    NAME             ARG     DESCRIPTION
+    -c, --config     STRING  Specify a custom config path.
+    -i, --interface  STRING  Interface name.
+```

--- a/tests/tesh/init.md
+++ b/tests/tesh/init.md
@@ -1,0 +1,16 @@
+# tesh: Testable init command example for hyprspace
+
+The init command generates random keys, so we use wildcards (`...`)
+to match non-deterministic portions like peer IDs.
+
+## Initialize a new config
+
+```console tesh-session="init"
+$ hyprspace init -i test0 -c /tmp/hyprspace-test.json
+Initialized new config at /tmp/hyprspace-test.json
+Add this entry to your other peers:
+{
+  "name": "...",
+  "id": "12D3KooW..."
+}
+```

--- a/tests/tesh/version.md
+++ b/tests/tesh/version.md
@@ -1,0 +1,6 @@
+# tesh: Testable CLI version output for hyprspace
+
+```console tesh-session="version"
+$ hyprspace version
+hyprspace develop
+```


### PR DESCRIPTION
   ## Add tesh tests for deterministic CLI commands as suggested in  #56                                                                                                                          
                                                                                                                                                                             
   Add [tesh](https://github.com/OceanSprint/tesh) (TEstable SHell sessions)                                                                                                 
   tests to verify the CLI help output and init command remain stable over time.                                                                                             
                                                                                                                                                                             
   ### What was added                                                                                                                                                        
                                                                                                                                                                             
   3 markdown test files under `tests/tesh/`:                                                                                                                                
                                                                                                                                                                             
   | File | Sessions | Tests |                                                                                                                                               
   |------|----------|-------|                                                                                                                                               
   | `help.md` | 7 | `hyprspace --help`, `hyprspace help`, `help <subcommand>` for all 6 subcommands |                                                                       
   | `init.md` | 1 | `hyprspace init` output with `...` wildcards for generated peer IDs |                                                                                   
   | `version.md` | 1 | `hyprspace version` output |                                                                                                                         
                                                                                                                                                                             
   ### How to run                                                                                                                                                            
                                                                                                                                                                             
   ```bash                                                                                                                                                                   
   pip install tesh                                                                                                                                                          
   tesh tests/tesh/     